### PR TITLE
Make benchmark work with node 0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,10 @@
     "devDependencies": {
         "mocha": ">= 0.8.1",
         "should": ">= 0.4.2"
+    },
+    "scripts": {
+        "test": "node_modules/.bin/mocha test/test.js",
+        "benchmark": "node test/benchmarks.js",
+        "benchmark-quick": "node test/benchmarks.js quick"
     }
 }

--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -261,9 +261,8 @@ if (typeof window !== 'undefined') {
 
     (function () {
         'use strict';
-        require.paths.push(__dirname + '/3rdparty/');
         var fs = require('fs'),
-            Benchmark = require('benchmark'),
+            Benchmark = require('./3rdparty/benchmark'),
             esprima = require('../esprima'),
             option = process.argv[2];
 


### PR DESCRIPTION
node 0.6 does not support require.paths anymore
this also adds npm script targets so test and benchmark can be run more easily

http://code.google.com/p/esprima/issues/detail?id=122
