### PR TITLE
ES6: egal operator 'is' and 'isnt' are contextual keyword

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -296,8 +296,6 @@ parseStatement: true, parseSourceElement: true */
         case 'if':
         case 'in':
         case 'instanceof':
-        case 'is':
-        case 'isnt':
         case 'new':
         case 'return':
         case 'switch':
@@ -1247,6 +1245,14 @@ parseStatement: true, parseSourceElement: true */
         return token.type === Token.Keyword && token.value === keyword;
     }
 
+
+    // Return true if the next token matches the specified contextual keyword
+
+    function matchContextualKeyword(keyword) {
+        var token = lookahead();
+        return token.type === Token.Identifier && token.value === keyword;
+    }
+
     // Return true if the next token is an assignment operator
 
     function matchAssign() {
@@ -1863,7 +1869,7 @@ parseStatement: true, parseSourceElement: true */
     function parseEqualityExpression() {
         var expr = parseRelationalExpression();
 
-        while ((!peekLineTerminator() && (matchKeyword('is') || matchKeyword('isnt'))) || match('==') || match('!=') || match('===') || match('!==')) {
+        while ((!peekLineTerminator() && (matchContextualKeyword('is') || matchContextualKeyword('isnt'))) || match('==') || match('!=') || match('===') || match('!==')) {
             expr = {
                 type: Syntax.BinaryExpression,
                 operator: lex().value,

--- a/test/test.js
+++ b/test/test.js
@@ -19445,17 +19445,17 @@ data = {
         },
 
         'x \n is y': {
-            index: 4,
+            index: 7,
             lineNumber: 2,
-            column: 2,
-            message: 'Error: Line 2: Unexpected token is'
+            column: 5,
+            message: 'Error: Line 2: Unexpected identifier'
         },
 
         'x \n isnt y': {
-            index: 4,
+            index: 9,
             lineNumber: 2,
-            column: 2,
-            message: 'Error: Line 2: Unexpected token isnt'
+            column: 7,
+            message: 'Error: Line 2: Unexpected identifier'
         },
 
         '\n\n\n{': {


### PR DESCRIPTION
See http://code.google.com/p/esprima/issues/detail?id=201
