### PR TITLE
Reject illegal numeric literal like '10E+'

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -791,7 +791,7 @@ parseStatement: true, parseSourceElement: true */
 
                     if (index < length) {
                         ch = source[index];
-                        if (isIdentifierStart(ch) || isDecimalDigit(ch)) {
+                        if (isIdentifierStart(ch)) {
                             throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
                         }
                     }
@@ -856,8 +856,14 @@ parseStatement: true, parseSourceElement: true */
 
         if (ch === 'e' || ch === 'E') {
             number += nextChar();
+
             ch = source[index];
-            if (ch === '+' || ch === '-' || isDecimalDigit(ch)) {
+            if (ch === '+' || ch === '-') {
+                number += nextChar();
+            }
+
+            ch = source[index];
+            if (isDecimalDigit(ch)) {
                 number += nextChar();
                 while (index < length) {
                     ch = source[index];
@@ -877,7 +883,7 @@ parseStatement: true, parseSourceElement: true */
 
         if (index < length) {
             ch = source[index];
-            if (isIdentifierStart(ch) || isDecimalDigit(ch)) {
+            if (isIdentifierStart(ch)) {
                 throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
             }
         }

--- a/test/test.js
+++ b/test/test.js
@@ -20044,6 +20044,34 @@ data = {
             message: 'Error: Line 1: Unexpected token ILLEGAL'
         },
 
+        '3in []': {
+            index: 1,
+            lineNumber: 1,
+            column: 2,
+            message: 'Error: Line 1: Unexpected token ILLEGAL'
+        },
+
+        '3e': {
+            index: 2,
+            lineNumber: 1,
+            column: 3,
+            message: 'Error: Line 1: Unexpected token ILLEGAL'
+        },
+
+        '3e+': {
+            index: 3,
+            lineNumber: 1,
+            column: 4,
+            message: 'Error: Line 1: Unexpected token ILLEGAL'
+        },
+
+        '3e-': {
+            index: 3,
+            lineNumber: 1,
+            column: 4,
+            message: 'Error: Line 1: Unexpected token ILLEGAL'
+        },
+
         '3x': {
             index: 1,
             lineNumber: 1,


### PR DESCRIPTION
See http://code.google.com/p/esprima/issues/detail?id=222 :-)
