### PR TITLE
SwitchCase range starts with consequent position

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2517,9 +2517,19 @@ parseStatement: true, parseSourceElement: true */
 
     // 12.10 The swith statement
 
-    function parseSwitchCase(test) {
-        var consequent = [],
+    function parseSwitchCase() {
+        var test,
+            consequent = [],
             statement;
+
+        if (matchKeyword('default')) {
+            lex();
+            test = null;
+        } else {
+            expectKeyword('case');
+            test = parseExpression();
+        }
+        expect(':');
 
         while (index < length) {
             if (match('}') || matchKeyword('default') || matchKeyword('case')) {
@@ -2540,7 +2550,7 @@ parseStatement: true, parseSourceElement: true */
     }
 
     function parseSwitchStatement() {
-        var discriminant, cases, test, oldInSwitch;
+        var discriminant, cases, oldInSwitch;
 
         expectKeyword('switch');
 
@@ -2569,17 +2579,7 @@ parseStatement: true, parseSourceElement: true */
             if (match('}')) {
                 break;
             }
-
-            if (matchKeyword('default')) {
-                lex();
-                test = null;
-            } else {
-                expectKeyword('case');
-                test = parseExpression();
-            }
-            expect(':');
-
-            cases.push(parseSwitchCase(test));
+            cases.push(parseSwitchCase());
         }
 
         state.inSwitch = oldInSwitch;

--- a/test/test.js
+++ b/test/test.js
@@ -3311,9 +3311,9 @@ data = {
                             end: { line: 1, column: 49 }
                         }
                     }],
-                    range: [41, 49],
+                    range: [18, 49],
                     loc: {
-                        start: { line: 1, column: 41 },
+                        start: { line: 1, column: 18 },
                         end: { line: 1, column: 49 }
                     }
                 }],
@@ -12419,9 +12419,9 @@ data = {
                         end: { line: 1, column: 39 }
                     }
                 }],
-                range: [27, 39],
+                range: [18, 39],
                 loc: {
-                    start: { line: 1, column: 27 },
+                    start: { line: 1, column: 18 },
                     end: { line: 1, column: 39 }
                 }
             }],
@@ -12489,9 +12489,9 @@ data = {
                         end: { line: 1, column: 39 }
                     }
                 }],
-                range: [27, 39],
+                range: [18, 39],
                 loc: {
-                    start: { line: 1, column: 27 },
+                    start: { line: 1, column: 18 },
                     end: { line: 1, column: 39 }
                 }
             }, {
@@ -12506,9 +12506,9 @@ data = {
                         end: { line: 1, column: 55 }
                     }
                 }],
-                range: [49, 55],
+                range: [40, 55],
                 loc: {
-                    start: { line: 1, column: 49 },
+                    start: { line: 1, column: 40 },
                     end: { line: 1, column: 55 }
                 }
             }],


### PR DESCRIPTION
I created pull request reflecting half-range changes.
http://code.google.com/p/esprima/issues/detail?id=248
