### PR TITLE
Harmony: Restrict eval and arguments in destructuring-assignment position

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2024,7 +2024,7 @@ parseStatement: true, parseSourceElement: true */
                 }
             }
         } else if (expr.type === Syntax.Identifier) {
-            if (expr.name === 'super') {
+            if (isRestrictedWord(expr.name)) {
                 throwError({}, Messages.InvalidLHSInAssignment);
             }
         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -16677,6 +16677,27 @@ data = {
             message: 'Error: Line 1: Unexpected token let'
         },
 
+        'var super': {
+            index: 4,
+            lineNumber: 1,
+            column: 5,
+            message: 'Error: Line 1: Unexpected reserved word'
+        },
+
+        '({ v: eval }) = obj': {
+            index: 13,
+            lineNumber: 1,
+            column: 14,
+            message: 'Error: Line 1: Invalid left-hand side in assignment'
+        },
+
+        '({ v: arguments }) = obj': {
+            index: 18,
+            lineNumber: 1,
+            column: 19,
+            message: 'Error: Line 1: Invalid left-hand side in assignment'
+        },
+
         '"use strict"; function static() { }': {
             index: 23,
             lineNumber: 1,


### PR DESCRIPTION
See http://code.google.com/p/esprima/issues/detail?id=242
