### PR TITLE
Fix scanRegExp else-if chain for JSLint

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -973,14 +973,11 @@ parseStatement: true, parseSourceElement: true */
                         throwError({}, Messages.UnterminatedRegExp);
                     }
                     str += ch;
-                }
-                else if (ch === '/') {
+                } else if (ch === '/') {
                     break;
-                }
-                else if (ch === '[') {
+                } else if (ch === '[') {
                     classMarker = true;
-                }
-                else if (isLineTerminator(ch)) {
+                } else if (isLineTerminator(ch)) {
                     throwError({}, Messages.UnterminatedRegExp);
                 }
             }


### PR DESCRIPTION
scanRegExp else-if chain violated JSLint style.

See http://code.google.com/p/esprima/issues/detail?id=266
