### PR TITLE
ES6: Support new integer literals

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -718,7 +718,7 @@ parseStatement: true, parseSourceElement: true, parseModuleBlock: true */
     // 7.8.3 Numeric Literals
 
     function scanNumericLiteral() {
-        var number, start, ch;
+        var number, start, ch, octal;
 
         ch = source[index];
         assert(isDecimalDigit(ch) || (ch === '.'),
@@ -795,8 +795,10 @@ parseStatement: true, parseSourceElement: true, parseModuleBlock: true */
                     };
                 } else if (ch === 'o' || ch === 'O' || isOctalDigit(ch)) {
                     if (isOctalDigit(ch)) {
+                        octal = true;
                         number = nextChar();
                     } else {
+                        octal = false;
                         nextChar();
                         number = '';
                     }
@@ -820,10 +822,11 @@ parseStatement: true, parseSourceElement: true, parseModuleBlock: true */
                             throwError({}, Messages.UnexpectedToken, 'ILLEGAL');
                         }
                     }
+
                     return {
                         type: Token.NumericLiteral,
                         value: parseInt(number, 8),
-                        octal: true,
+                        octal: octal,
                         lineNumber: lineNumber,
                         lineStart: lineStart,
                         range: [start, index]

--- a/test/test.js
+++ b/test/test.js
@@ -3988,6 +3988,68 @@ data = {
             }
         },
 
+        'function test() {\'use strict\'; 0o0; }': {
+            type: 'FunctionDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'test',
+                range: [9, 13],
+                loc: {
+                    start: { line: 1, column: 9 },
+                    end: { line: 1, column: 13 }
+                }
+            },
+            params: [],
+            body: {
+                type: 'BlockStatement',
+                body: [{
+                    type: 'ExpressionStatement',
+                    expression: {
+                        type: 'Literal',
+                        value: 'use strict',
+                        raw: '\'use strict\'',
+                        range: [17, 29],
+                        loc: {
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 29 }
+                        }
+                    },
+                    range: [17, 30],
+                    loc: {
+                        start: { line: 1, column: 17 },
+                        end: { line: 1, column: 30 }
+                    }
+                }, {
+                    type: 'ExpressionStatement',
+                    expression: {
+                        type: 'Literal',
+                        value: 0,
+                        raw: '0o0',
+                        range: [31, 34],
+                        loc: {
+                            start: { line: 1, column: 31 },
+                            end: { line: 1, column: 34 }
+                        }
+                    },
+                    range: [31, 35],
+                    loc: {
+                        start: { line: 1, column: 31 },
+                        end: { line: 1, column: 35 }
+                    }
+                }],
+                range: [16, 37],
+                loc: {
+                    start: { line: 1, column: 16 },
+                    end: { line: 1, column: 37 }
+                }
+            },
+            range: [0, 37],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 37 }
+            }
+        },
+
         '0o2': {
             type: 'ExpressionStatement',
             expression: {
@@ -4042,6 +4104,68 @@ data = {
             loc: {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 3 }
+            }
+        },
+
+        'function test() {\'use strict\'; 0O0; }': {
+            type: 'FunctionDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'test',
+                range: [9, 13],
+                loc: {
+                    start: { line: 1, column: 9 },
+                    end: { line: 1, column: 13 }
+                }
+            },
+            params: [],
+            body: {
+                type: 'BlockStatement',
+                body: [{
+                    type: 'ExpressionStatement',
+                    expression: {
+                        type: 'Literal',
+                        value: 'use strict',
+                        raw: '\'use strict\'',
+                        range: [17, 29],
+                        loc: {
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 29 }
+                        }
+                    },
+                    range: [17, 30],
+                    loc: {
+                        start: { line: 1, column: 17 },
+                        end: { line: 1, column: 30 }
+                    }
+                }, {
+                    type: 'ExpressionStatement',
+                    expression: {
+                        type: 'Literal',
+                        value: 0,
+                        raw: '0O0',
+                        range: [31, 34],
+                        loc: {
+                            start: { line: 1, column: 31 },
+                            end: { line: 1, column: 34 }
+                        }
+                    },
+                    range: [31, 35],
+                    loc: {
+                        start: { line: 1, column: 31 },
+                        end: { line: 1, column: 35 }
+                    }
+                }],
+                range: [16, 37],
+                loc: {
+                    start: { line: 1, column: 16 },
+                    end: { line: 1, column: 37 }
+                }
+            },
+            range: [0, 37],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 37 }
             }
         },
 


### PR DESCRIPTION
Implement OctalIntegerLiteral and BinaryIntegerLiteral in 2 commits. :-)

See
http://code.google.com/p/esprima/issues/detail?id=270
http://code.google.com/p/esprima/issues/detail?id=271
