### PR TITLE
Fix order of operations for `^` and `|` operators

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1866,14 +1866,14 @@ parseStatement: true, parseSourceElement: true */
         return expr;
     }
 
-    function parseBitwiseORExpression() {
+    function parseBitwiseXORExpression() {
         var expr = parseBitwiseANDExpression();
 
-        while (match('|')) {
+        while (match('^')) {
             lex();
             expr = {
                 type: Syntax.BinaryExpression,
-                operator: '|',
+                operator: '^',
                 left: expr,
                 right: parseBitwiseANDExpression()
             };
@@ -1882,16 +1882,16 @@ parseStatement: true, parseSourceElement: true */
         return expr;
     }
 
-    function parseBitwiseXORExpression() {
-        var expr = parseBitwiseORExpression();
+    function parseBitwiseORExpression() {
+        var expr = parseBitwiseXORExpression();
 
-        while (match('^')) {
+        while (match('|')) {
             lex();
             expr = {
                 type: Syntax.BinaryExpression,
-                operator: '^',
+                operator: '|',
                 left: expr,
-                right: parseBitwiseORExpression()
+                right: parseBitwiseXORExpression()
             };
         }
 
@@ -1901,7 +1901,7 @@ parseStatement: true, parseSourceElement: true */
     // 11.11 Binary Logical Operators
 
     function parseLogicalANDExpression() {
-        var expr = parseBitwiseXORExpression();
+        var expr = parseBitwiseORExpression();
 
         while (match('&&')) {
             lex();
@@ -1909,7 +1909,7 @@ parseStatement: true, parseSourceElement: true */
                 type: Syntax.LogicalExpression,
                 operator: '&&',
                 left: expr,
-                right: parseBitwiseXORExpression()
+                right: parseBitwiseORExpression()
             };
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -7606,20 +7606,20 @@ data = {
             type: 'ExpressionStatement',
             expression: {
                 type: 'BinaryExpression',
-                operator: '^',
+                operator: '|',
                 left: {
+                    type: 'Identifier',
+                    name: 'x',
+                    range: [0, 1],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 1 }
+                    }
+                },
+                right: {
                     type: 'BinaryExpression',
-                    operator: '|',
+                    operator: '^',
                     left: {
-                        type: 'Identifier',
-                        name: 'x',
-                        range: [0, 1],
-                        loc: {
-                            start: { line: 1, column: 0 },
-                            end: { line: 1, column: 1 }
-                        }
-                    },
-                    right: {
                         type: 'Identifier',
                         name: 'y',
                         range: [4, 5],
@@ -7628,18 +7628,18 @@ data = {
                             end: { line: 1, column: 5 }
                         }
                     },
-                    range: [0, 5],
+                    right: {
+                        type: 'Identifier',
+                        name: 'z',
+                        range: [8, 9],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 9 }
+                        }
+                    },
+                    range: [4, 9],
                     loc: {
-                        start: { line: 1, column: 0 },
-                        end: { line: 1, column: 5 }
-                    }
-                },
-                right: {
-                    type: 'Identifier',
-                    name: 'z',
-                    range: [8, 9],
-                    loc: {
-                        start: { line: 1, column: 8 },
+                        start: { line: 1, column: 4 },
                         end: { line: 1, column: 9 }
                     }
                 },


### PR DESCRIPTION
As covered in ECMAScript Language Specification Section 11.10,
`^` binds more tightly than `|`.

http://code.google.com/p/esprima/issues/detail?id=277
