### PR TITLE
ES6: "module" keyword conflict

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -17870,7 +17870,7 @@ data = {
                 loc: {
                     start: { line: 1, column: 19 },
                     end: { line: 1, column: 28 }
-                }                
+                }
             }],
             from: {
                 type: 'Path',
@@ -17894,8 +17894,79 @@ data = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 41 }
             }
-        }
+        },
 
+        'module\n X = Y': {
+            type: "ExpressionStatement",
+            expression: {
+                type: "Identifier",
+                name: "module",
+                range: [0, 6],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 6 }
+                }
+            },
+            range: [0, 8],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 2, column: 1 }
+            }
+        },
+
+        'module.export = Foo': {
+            type: "ExpressionStatement",
+            expression: {
+                type: "AssignmentExpression",
+                operator: "=",
+                left: {
+                    type: "MemberExpression",
+                    computed: false,
+                    object: {
+                        type: "Identifier",
+                        name: "module",
+                        range: [0, 6],
+                        loc: {
+                            start: { line: 1, column: 0 },
+                            end: { line: 1, column: 6 }
+                        }
+                    },
+                    property: {
+                        type: "Identifier",
+                        name: "export",
+                        range: [7, 13],
+                        loc: {
+                            start: { line: 1, column: 7 },
+                            end: { line: 1, column: 13 }
+                        }
+                    },
+                    range: [0, 13],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 13 }
+                    }
+                },
+                right: {
+                    type: "Identifier",
+                    name: "Foo",
+                    range: [16, 19],
+                    loc: {
+                        start: { line: 1, column: 16 },
+                        end: { line: 1, column: 19 }
+                    }
+                },
+                range: [0, 19],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 19 }
+                }
+            },
+            range: [0, 19],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 19 }
+            }
+        }
     },
 
     'Invalid syntax': {
@@ -18747,7 +18818,7 @@ data = {
             column: 5,
             message: 'Error: Line 1: Invalid regular expression: missing /'
         },
-        
+
         '//\r \n]': {
             index: 5,
             lineNumber: 3,
@@ -19461,20 +19532,6 @@ data = {
             lineNumber: 1,
             column: 10,
             message: 'Error: Line 1: Unexpected identifier'
-        },
-
-        'module\n X = Y': {
-            index: 6,
-            lineNumber: 1,
-            column: 7,
-            message: 'Error: Line 1: Illegal newline after module'
-        },
-
-        'module\n X = "Y"': {
-            index: 6,
-            lineNumber: 1,
-            column: 7,
-            message: 'Error: Line 1: Illegal newline after module'
         },
 
         'export for': {


### PR DESCRIPTION
module was not (and is still not) a keyword. Making it a keyword conflicts with existing code, particularly with CommonJS module variable. Consider an expression

  module.exports = Foo;

This was (and AFIU still is) a valid expression. Parser should be able to discern between an expression using module as an Identifier and a module declaration that uses module as a Keyword.

This diff makes the parser more intelligent, though somewhat less effective when parsing expression with module.
"module identifier ..." is considered a module declaration, while everything else is considered as a statement

Updated tests. Removed a newline check, since

  module
  x = y

is a perfectly valid piece of code: variable module followed by an assignment.

http://code.google.com/p/esprima/issues/detail?id=280
