### PR TITLE
Fix invalid start location for CallStatement

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4148,6 +4148,15 @@ parseYieldExpression: true
                             node.loc.start = node.object.loc.start;
                         }
                     }
+
+                    if (node.type === Syntax.CallExpression) {
+                        if (typeof node.callee.range !== 'undefined') {
+                            node.range[0] = node.callee.range[0];
+                        }
+                        if (typeof node.callee.loc !== 'undefined') {
+                            node.loc.start = node.callee.loc.start;
+                        }
+                    }
                     return node;
                 }
             };

--- a/test/test.js
+++ b/test/test.js
@@ -6250,9 +6250,9 @@ data = {
                             end: { line: 1, column: 11 }
                         }
                     }],
-                    range: [8, 12],
+                    range: [0, 12],
                     loc: {
-                        start: { line: 1, column: 8 },
+                        start: { line: 1, column: 0 },
                         end: { line: 1, column: 12 }
                     }
                 },
@@ -6265,9 +6265,9 @@ data = {
                         end: { line: 1, column: 21 }
                     }
                 },
-                range: [8, 21],
+                range: [0, 21],
                 loc: {
-                    start: { line: 1, column: 8 },
+                    start: { line: 1, column: 0 },
                     end: { line: 1, column: 21 }
                 }
             },
@@ -6309,9 +6309,9 @@ data = {
                                     end: { line: 1, column: 11 }
                                 }
                             }],
-                            range: [8, 12],
+                            range: [0, 12],
                             loc: {
-                                start: { line: 1, column: 8 },
+                                start: { line: 1, column: 0 },
                                 end: { line: 1, column: 12 }
                             }
                         },
@@ -6324,9 +6324,9 @@ data = {
                                 end: { line: 1, column: 21 }
                             }
                         },
-                        range: [8, 21],
+                        range: [0, 21],
                         loc: {
-                            start: { line: 1, column: 8 },
+                            start: { line: 1, column: 0 },
                             end: { line: 1, column: 21 }
                         }
                     },
@@ -6358,9 +6358,9 @@ data = {
                             end: { line: 1, column: 31 }
                         }
                     }],
-                    range: [21, 32],
+                    range: [0, 32],
                     loc: {
-                        start: { line: 1, column: 21 },
+                        start: { line: 1, column: 0 },
                         end: { line: 1, column: 32 }
                     }
                 },
@@ -6373,9 +6373,9 @@ data = {
                         end: { line: 1, column: 41 }
                     }
                 },
-                range: [21, 41],
+                range: [0, 41],
                 loc: {
-                    start: { line: 1, column: 21 },
+                    start: { line: 1, column: 0 },
                     end: { line: 1, column: 41 }
                 }
             },
@@ -20354,9 +20354,9 @@ data = {
                         }
                     },
                     'arguments': [],
-                    range: [0, 43],
+                    range: [1, 43],
                     loc: {
-                        start: { line: 1, column: 0 },
+                        start: { line: 1, column: 1 },
                         end: { line: 1, column: 43 }
                     }
                 },
@@ -20440,9 +20440,9 @@ data = {
                         }
                     },
                     'arguments': [],
-                    range: [0, 37],
+                    range: [1, 37],
                     loc: {
-                        start: { line: 1, column: 0 },
+                        start: { line: 1, column: 1 },
                         end: { line: 1, column: 37 }
                     }
                 },


### PR DESCRIPTION
Same change, merged into harmony branch

CallStatement was returning a position of '(' as a start location. It should return the position of the actual beginning of the statement instead. Example

  parse("universe(42)")

was returning
  {
    type: 'CallExpression',
    ...
    range: [0, 12]
  }

while it should
  {
    type: 'CallExpression',
    ...
    range: [8, 12]
  }

Update the wrapper function and fix tests.

http://code.google.com/p/esprima/issues/detail?id=278

Conflicts:

```
test/test.js
```
