### PR TITLE
Fix to match parenthesis of wrapped member or call expressions.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3372,6 +3372,21 @@ parseStatement: true, parseSourceElement: true */
                 }
             }
 
+            function getMin(loc1, loc2) {
+                if (loc1.line < loc2.line) {
+                    return loc1;
+                }
+                if (loc1.line > loc2.line) {
+                    return loc2;
+                }
+                // if-else instead of ternary for valid coverage test
+                if (loc1.column < loc2.column) {
+                    return loc1;
+                } else {
+                    return loc2;
+                }
+            }
+
             return function () {
                 var node, rangeInfo, locInfo;
 
@@ -3406,19 +3421,23 @@ parseStatement: true, parseSourceElement: true */
 
                     if (node.type === Syntax.MemberExpression) {
                         if (typeof node.object.range !== 'undefined') {
-                            node.range[0] = node.object.range[0];
+                            if (node.object.range[0] < node.range[0]) {
+                                node.range[0] = node.object.range[0];
+                            }
                         }
                         if (typeof node.object.loc !== 'undefined') {
-                            node.loc.start = node.object.loc.start;
+                            node.loc.start = getMin(node.loc.start, node.object.loc.start);
                         }
                     }
 
                     if (node.type === Syntax.CallExpression) {
                         if (typeof node.callee.range !== 'undefined') {
-                            node.range[0] = node.callee.range[0];
+                            if (node.callee.range[0] < node.range[0]) {
+                                node.range[0] = node.callee.range[0];
+                            }
                         }
                         if (typeof node.callee.loc !== 'undefined') {
-                            node.loc.start = node.callee.loc.start;
+                            node.loc.start = getMin(node.loc.start, node.callee.loc.start);
                         }
                     }
                     return node;

--- a/test/test.js
+++ b/test/test.js
@@ -10251,6 +10251,199 @@ var testFixture = {
 
     },
 
+    'Expressions in parenthesis': {
+
+        '(func())': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'func',
+                    range: [1, 5],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 5 }
+                    }
+                },
+                arguments: [],
+                range: [0, 8],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 8 }
+                }
+            },
+            range: [0, 8],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 8 }
+            }
+        },
+
+        '(\nfunc()\n)': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'func',
+                    range: [2, 6],
+                    loc: {
+                        start: { line: 2, column: 0 },
+                        end: { line: 2, column: 4 }
+                    }
+                },
+                arguments: [],
+                range: [0, 10],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 3, column: 1 }
+                }
+            },
+            range: [0, 10],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 3, column: 1 }
+            }
+        },
+
+        '(object.property)': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'MemberExpression',
+                computed: false,
+                object: {
+                    type: 'Identifier',
+                    name: 'object',
+                    range: [1, 7],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 7 }
+                    }
+                },
+                property: {
+                    type: 'Identifier',
+                    name: 'property',
+                    range: [8, 16],
+                    loc: {
+                        start: { line: 1, column: 8 },
+                        end: { line: 1, column: 16 }
+                    }
+                },
+                range: [0, 17],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 17 }
+                }
+            },
+            range: [0, 17],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 17 }
+            }
+        },
+
+        '(\nobject\n.property\n.sub\n)': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'MemberExpression',
+                computed: false,
+                object: {
+                    type: 'MemberExpression',
+                    computed: false,
+                    object: {
+                        type: 'Identifier',
+                        name: 'object',
+                        range: [2, 8],
+                        loc: {
+                            start: { line: 2, column: 0 },
+                            end: { line: 2, column: 6 }
+                        }
+                    },
+                    property: {
+                        type: 'Identifier',
+                        name: 'property',
+                        range: [10, 18],
+                        loc: {
+                            start: { line: 3, column: 1 },
+                            end: { line: 3, column: 9 }
+                        }
+                    },
+                    range: [2, 18],
+                    loc: {
+                        start: { line: 2, column: 0 },
+                        end: { line: 3, column: 9 }
+                    }
+                },
+                property: {
+                    type: 'Identifier',
+                    name: 'sub',
+                    range: [20, 23],
+                    loc: {
+                        start: { line: 4, column: 1 },
+                        end: { line: 4, column: 4 }
+                    }
+                },
+                range: [0, 25],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 5, column: 1 }
+                }
+            },
+            range: [0, 25],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 5, column: 1 }
+            }
+        },
+
+        '(object.method())': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'MemberExpression',
+                    computed: false,
+                    object: {
+                        type: 'Identifier',
+                        name: 'object',
+                        range: [1, 7],
+                        loc: {
+                            start: { line: 1, column: 1 },
+                            end: { line: 1, column: 7 }
+                        }
+                    },
+                    property: {
+                        type: 'Identifier',
+                        name: 'method',
+                        range: [8, 14],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 14 }
+                        }
+                    },
+                    range: [1, 14],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 14 }
+                    }
+                },
+                arguments: [],
+                range: [0, 17],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 17 }
+                }
+            },
+            range: [0, 17],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 17 }
+            }
+        }
+
+    },
+
     'If Statement': {
 
         'if (morning) goodMorning()': {
@@ -16945,9 +17138,9 @@ var testFixture = {
                         }
                     },
                     'arguments': [],
-                    range: [1, 43],
+                    range: [0, 43],
                     loc: {
-                        start: { line: 1, column: 1 },
+                        start: { line: 1, column: 0 },
                         end: { line: 1, column: 43 }
                     }
                 },
@@ -17034,9 +17227,9 @@ var testFixture = {
                         }
                     },
                     'arguments': [],
-                    range: [1, 37],
+                    range: [0, 37],
                     loc: {
-                        start: { line: 1, column: 1 },
+                        start: { line: 1, column: 0 },
                         end: { line: 1, column: 37 }
                     }
                 },


### PR DESCRIPTION
The character range of MemberExpression in "(a.b)" was "a.b)".
The commit fixes this problem by returning the range of "(a.b)"
in these cases.

Two of already existing unit tests were expecting wrong result
for inputs like "(function () { ... }())". These are updated to
expect the full range of expression.

Few additional test cases are added to test the parsing of
similar expressions and cover all the added and modified lines.

http://code.google.com/p/esprima/issues/detail?id=320
