### PR TITLE
Fix incorrect range of expressions inside parentheses

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3387,12 +3387,12 @@ parseStatement: true, parseSourceElement: true */
                 node = parseFunction.apply(null, arguments);
                 if (typeof node !== 'undefined') {
 
-                    if (range) {
+                    if (range && typeof node.range === 'undefined') {
                         rangeInfo[1] = index;
                         node.range = rangeInfo;
                     }
 
-                    if (loc) {
+                    if (loc && typeof node.loc === 'undefined') {
                         locInfo.end = {
                             line: lineNumber,
                             column: index - lineStart

--- a/test/test.js
+++ b/test/test.js
@@ -166,10 +166,10 @@ var testFixture = {
                             end: { line: 1, column: 6 }
                         }
                     },
-                    range: [0, 8],
+                    range: [1, 6],
                     loc: {
-                        start: { line: 1, column: 0 },
-                        end: { line: 1, column: 8 }
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 6 }
                     }
                 },
                 right: {
@@ -10328,10 +10328,10 @@ var testFixture = {
                     rest: null,
                     generator: false,
                     expression: false,
-                    range: [13, 27],
+                    range: [14, 26],
                     loc: {
-                        start: { line: 1, column: 13 },
-                        end: { line: 1, column: 27 }
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 26 }
                     }
                 },
                 range: [13, 27],
@@ -12418,10 +12418,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 22],
+                range: [1, 21],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 22 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 21 }
                 }
             },
             range: [0, 22],
@@ -12460,10 +12460,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 23],
+                range: [1, 22],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 23 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 22 }
                 }
             },
             range: [0, 23],
@@ -12510,10 +12510,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 25],
+                range: [1, 24],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 25 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 24 }
                 }
             },
             range: [0, 25],
@@ -12578,10 +12578,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 28],
+                range: [1, 27],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 28 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 27 }
                 }
             },
             range: [0, 28],
@@ -13906,10 +13906,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 25],
+                range: [1, 24],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 25 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 24 }
                 }
             },
             range: [0, 25],
@@ -14429,10 +14429,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 14],
+                range: [1, 13],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 14 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 1, column: 13 }
                 }
             },
             range: [0, 14],
@@ -15023,10 +15023,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 25],
+                range: [1, 24],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 2, column: 5 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 2, column: 4 }
                 }
             },
             range: [0, 25],
@@ -15082,10 +15082,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 36],
+                range: [1, 35],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 2, column: 5 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 2, column: 4 }
                 }
             },
             range: [0, 36],
@@ -15141,10 +15141,10 @@ var testFixture = {
                 rest: null,
                 generator: false,
                 expression: false,
-                range: [0, 47],
+                range: [1, 46],
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 2, column: 15 }
+                    start: { line: 1, column: 1 },
+                    end: { line: 2, column: 14 }
                 }
             },
             range: [0, 47],
@@ -16945,10 +16945,10 @@ var testFixture = {
                         }
                     },
                     'arguments': [],
-                    range: [1, 43],
+                    range: [1, 42],
                     loc: {
                         start: { line: 1, column: 1 },
-                        end: { line: 1, column: 43 }
+                        end: { line: 1, column: 42 }
                     }
                 },
                 range: [0, 43],
@@ -17034,10 +17034,10 @@ var testFixture = {
                         }
                     },
                     'arguments': [],
-                    range: [1, 37],
+                    range: [1, 36],
                     loc: {
                         start: { line: 1, column: 1 },
-                        end: { line: 1, column: 37 }
+                        end: { line: 1, column: 36 }
                     }
                 },
                 range: [0, 37],


### PR DESCRIPTION
The character range of expressions in parentheses have included
the parentheses as well.

An example: "(42)"
Incorrect range of literal:   [0,4]
The correct range of literal: [1,3]

Furthermore in case of MemberExpression and CallExpression the
range have included the closing parenthesis but not the opening.
The commit fixes that as well.

An example: "(f())"
Incorrect range of call expression:   [1,5]
The correct range of call expression: [1,4]

13 tests have been updateded to expect the correct range.

http://code.google.com/p/esprima/issues/detail?id=309
