### PR TITLE
Added string property to Error.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1499,11 +1499,13 @@ parseStatement: true, parseSourceElement: true */
             error.index = token.range[0];
             error.lineNumber = token.lineNumber;
             error.column = token.range[0] - lineStart + 1;
+            error.string = msg;
         } else {
             error = new Error('Line ' + lineNumber + ': ' + msg);
             error.index = index;
             error.lineNumber = lineNumber;
             error.column = index - lineStart + 1;
+            error.string = msg;
         }
 
         throw error;


### PR DESCRIPTION
This is probably not the best implementation but it should be illustrative enough.

The idea here is that I would like to have the error message without the "Line #: ". I could regex it but I think it would be neat to be able to get a clean message just like we get the clean line number.
