### PR TITLE
Update bin/esvalidate.js

### DIFF
--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -148,6 +148,7 @@ fnames.forEach(function (fname) {
         }
     } catch (e) {
         console.log('Error: ' + e.message);
+        process.exit(1);
     }
 });
 


### PR DESCRIPTION
when there is a parsing exception (that happens during esprima.parse() execution) it should set the status code, otherwise it might be 0. The proposed solution is imply to abort directly with the status code.
