### PR TITLE
Adapt esvalidate.js to run under PhantomJS as well as Node and Rhino	

### DIFF
--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -25,17 +25,34 @@
 
 /*jslint sloppy:true plusplus:true node:true rhino:true */
 
-var fs, esprima, options, fnames, count;
+var fs, system, esprima, options, fnames, count;
 
-if (typeof require === 'function') {
-    fs = require('fs');
-    esprima = require('esprima');
-} else if (typeof load === 'function') {
-    try {
-        load('esprima.js');
-    } catch (e) {
-        load('../esprima.js');
+if (typeof esprima === 'undefined'){
+    // PhantomJS can only require() relative files
+    if (typeof phantom === 'object') {
+        fs = require('fs');
+        system = require('system');
+        esprima = require('./esprima');
+    } else if (typeof require === 'function') {
+        fs = require('fs');
+        esprima = require('esprima');
+    } else if (typeof load === 'function') {
+        try {
+            load('esprima.js');
+        } catch (e) {
+            load('../esprima.js');
+        }
     }
+}
+
+// Shims to Node.js objects when running under PhantomJS 1.7+.
+if (typeof phantom === 'object') {
+    fs.readFileSync = fs.read;
+    process = {
+        argv: [].slice.call(system.args),
+        exit: phantom.exit
+    };
+    process.argv.unshift('phantomjs');
 }
 
 // Shims to Node.js objects when running under Rhino.
@@ -163,4 +180,8 @@ if (options.format === 'junit') {
 
 if (count > 0) {
     process.exit(1);
+}
+
+if (count === 0 && typeof phantom === 'object') {
+    process.exit(0);
 }


### PR DESCRIPTION
I love PhantomJS, and find it much more convenient to use & distribute than node.js, so I added checks and shims for esvalidate.js to run under PhantomJS 1.7+ as well as Node and Rhino.

http://code.google.com/p/esprima/issues/detail?id=373
