### PR TITLE
Fix JUnit report format for thrown error (non SyntaxError).

### DIFF
--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -153,7 +153,18 @@ fnames.forEach(function (fname) {
         }
     } catch (e) {
         ++count;
-        console.log('Error: ' + e.message);
+        if (options.format === 'junit') {
+            console.log('<testsuite name="' + fname + '" errors="1" failures="0" tests="1" ' +
+                ' time="' + Math.round((Date.now() - timestamp) / 1000) + '">');
+            console.log(' <testcase name="' + e.message + '" ' + ' time="0">');
+            console.log(' <error type="ParseError" message="' + e.message + '">' +
+                e.message + '(' + fname + ((e.lineNumber) ? ':' + e.lineNumber : '') +
+                ')</error>');
+            console.log(' </testcase>');
+            console.log('</testsuite>');
+        } else {
+            console.log('Error: ' + e.message);
+        }
     }
 });
 


### PR DESCRIPTION
Thrown error should also be formatted as testsuite>testcase>error,
just like a SyntaxError, so that tools like Jenkins JUnit report
visualisation includes the thrown error.

There is no parsing performance impact since this only affects
esvalidate error thrown per file.

http://code.google.com/p/esprima/issues/detail?id=374
