### PR TITLE
SourceMap support for multiple source file names

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3387,8 +3387,8 @@ parseStatement: true, parseSourceElement: true */
             }
         };
         if (extra.loc && extra.loc.source) {
-            marker.loc.source = extra.loc.source
-        };
+            marker.loc.source = extra.loc.source;
+        }
 
         marker.end = function () {
             this.range[1] = index;
@@ -3412,8 +3412,8 @@ parseStatement: true, parseSourceElement: true */
                     }
                 };
                 if (extra.loc.source) {
-                    node.groupLoc.source = extra.loc.source
-                };
+                    node.groupLoc.source = extra.loc.source;
+                }
             }
         };
 
@@ -3433,8 +3433,8 @@ parseStatement: true, parseSourceElement: true */
                     }
                 };
                 if (extra.loc.source) {
-                    node.loc.source = extra.loc.source
-                };
+                    node.loc.source = extra.loc.source;
+                }
             }
         };
 
@@ -3569,16 +3569,16 @@ parseStatement: true, parseSourceElement: true */
                             end: end
                         };
                         if (loc.source) {
-                            node.groupLoc.source = loc.source
-                        };
+                            node.loc.source = loc.source;
+                        }
                     } else if (typeof node.loc === 'undefined') {
                         node.loc = {
                             start: node.left.loc.start,
                             end: node.right.loc.end
                         };
                         if (loc.source) {
-                            node.loc.source = loc.source
-                        };
+                            node.loc.source = loc.source;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
ESCodeGen now supports generating sourcemaps for AST tree that came from multiple source files.

https://github.com/Constellation/escodegen/pull/61

ESCodeGen looks at the `loc.source` property as defined in the spec https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API

If `loc.source` is defined it uses that entry value as filename for the generation of sourcemap.

With the proposed commit ESPrima now inserts the file name of the source into each `loc` node in parsed AST tree when `options.loc.source` is defined:

```
var a = ep.parse('var a = 1', {loc:{source:'filenameA.js'}});
var b = ep.parse('var b = 2', {loc:{source:'filenameB.js'}});

// joining the two AST trees
var c = {'type':'Program',body:[].concat(a.body, b.body)};

ec.generate(c);
// output:
'var a = 1;\nvar b = 2;'

ec.generate(c, {sourceMap:true});
// output:
{"version":3,"file":true,"sources":["filenameA.js","filenameB.js"],"names":[],"mappings":"AAAA,GAAA,CAAI,IAAI,CAAR;ACAA,GAAA,CAAI,IAAI,CAAR"}
```
