### PR TITLE
add func `adjustRegexLiteral` in esparse core and cli argument for that

### DIFF
--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -27,6 +27,7 @@
 /*jslint sloppy:true node:true rhino:true */
 
 var fs, esprima, fname, content, options, syntax;
+var adjustRegexLiteral = null;
 
 if (typeof require === 'function') {
     fs = require('fs');
@@ -91,6 +92,8 @@ process.argv.splice(2).forEach(function (entry) {
         options.tokens = true;
     } else if (entry === '--tolerant') {
         options.tolerant = true;
+    } else if (entry === '--regexp') {
+        adjustRegexLiteral = esprima.adjustRegexLiteral;
     } else if (entry.slice(0, 2) === '--') {
         console.log('Error: unknown option ' + entry + '.');
         process.exit(1);
@@ -110,7 +113,7 @@ if (typeof fname !== 'string') {
 try {
     content = fs.readFileSync(fname, 'utf-8');
     syntax = esprima.parse(content, options);
-    console.log(JSON.stringify(syntax, null, 4));
+    console.log(JSON.stringify(syntax, adjustRegexLiteral, 4));
 } catch (e) {
     console.log('Error: ' + e.message);
     process.exit(1);

--- a/demo/parse.html
+++ b/demo/parse.html
@@ -201,12 +201,6 @@ function parse(delay) {
         // Special handling for regular expression literal since we need to
         // convert it to a string literal, otherwise it will be decoded
         // as object "{}" and the regular expression would be lost.
-        function adjustRegexLiteral(key, value) {
-            if (key === 'value' && value instanceof RegExp) {
-                value = value.toString();
-            }
-            return value;
-        }
 
         if (typeof window.editor === 'undefined') {
             code = document.getElementById('code').value;
@@ -226,10 +220,10 @@ function parse(delay) {
         try {
 
             result = esprima.parse(code, options);
-            str = JSON.stringify(result, adjustRegexLiteral, 4);
+            str = JSON.stringify(result, esparse.adjustRegexLiteral, 4);
             options.tokens = true;
             document.getElementById('tokens').value = JSON.stringify(esprima.parse(code, options).tokens,
-                adjustRegexLiteral, 4);
+                esparse.adjustRegexLiteral, 4);
             updateTree(result);
         } catch (e) {
             updateTree();

--- a/esprima.js
+++ b/esprima.js
@@ -1011,6 +1011,17 @@ parseStatement: true, parseSourceElement: true */
             range: [start, index]
         };
     }
+// Special handling for regular expression literal since we need to
+// convert it to a string literal, otherwise it will be decoded
+// as object "{}" and the regular expression would be lost.
+
+    function adjustRegexLiteral(key, value) {
+        if (value && value.type === 'Literal' && value.value instanceof RegExp) {
+            value.type  = 'RegularExpression';
+            value.value = value.value.toString();
+        }
+        return value;
+    }
 
     function isIdentifierName(token) {
         return token.type === Token.Identifier ||
@@ -3787,7 +3798,7 @@ parseStatement: true, parseSourceElement: true */
     exports.version = '1.1.0-dev';
 
     exports.parse = parse;
-
+    exports.adjustRegexLiteral = adjustRegexLiteral;
     // Deep copy.
     exports.Syntax = (function () {
         var name, types = {};

--- a/test/module.js
+++ b/test/module.js
@@ -47,6 +47,7 @@ function runTests() {
         variables = {
             'version': 'string',
             'parse': 'function',
+            'adjustRegexLiteral': 'function',
             'Syntax': 'object',
             'Syntax.AssignmentExpression': 'string',
             'Syntax.ArrayExpression': 'string',


### PR DESCRIPTION
Special handling for regular expression literal since we need to
 convert it to an object with type = "RegularExpression", otherwise
 it will be decoded as object "{}" and the regular expression would be lost.

Tests are not affected except a new one is added in test/modules.js to test load

http://code.google.com/p/esprima/issues/detail?id=390
