### PR TITLE
Add a Tokenizer API.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -54,6 +54,7 @@ parseStatement: true, parseSourceElement: true */
 
     var Token,
         TokenName,
+        FnExprTokens,
         Syntax,
         PropertyKind,
         Messages,
@@ -78,7 +79,8 @@ parseStatement: true, parseSourceElement: true */
         NullLiteral: 5,
         NumericLiteral: 6,
         Punctuator: 7,
-        StringLiteral: 8
+        StringLiteral: 8,
+        RegularExpression: 9
     };
 
     TokenName = {};
@@ -90,6 +92,18 @@ parseStatement: true, parseSourceElement: true */
     TokenName[Token.NumericLiteral] = 'Numeric';
     TokenName[Token.Punctuator] = 'Punctuator';
     TokenName[Token.StringLiteral] = 'String';
+    TokenName[Token.RegularExpression] = 'RegularExpression';
+
+    // A function following one of those tokens is an expression.
+    FnExprTokens = ["(", "{", "[", "in", "typeof", "instanceof", "new",
+                    "return", "case", "delete", "throw", "void",
+                    // assignment operators
+                    "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+                    "&=", "|=", "^=", ",",
+                    // binary/unary operators
+                    "+", "-", "*", "/", "%", "++", "--", "<<", ">>", ">>>", "&",
+                    "|", "^", "!", "~", "&&", "||", "?", ":", "===", "==", ">=",
+                    "<=", "<", ">", "!=", "!=="];
 
     Syntax = {
         AssignmentExpression: 'AssignmentExpression',
@@ -535,6 +549,13 @@ parseStatement: true, parseSourceElement: true */
         case 63:   // ?
         case 126:  // ~
             ++index;
+            if (extra.tokenize) {
+                if (code === 40) {
+                    extra.openParenToken = extra.tokens.length;
+                } else if (code === 123) {
+                    extra.openCurlyToken = extra.tokens.length;
+                }
+            }
             return {
                 type: Token.Punctuator,
                 value: String.fromCharCode(code),
@@ -989,6 +1010,16 @@ parseStatement: true, parseSourceElement: true */
 
         peek();
 
+
+        if (extra.tokenize) {
+            return {
+                type: Token.RegularExpression,
+                value: value,
+                lineNumber: lineNumber,
+                lineStart: lineStart,
+                range: [start, index]
+            };
+        }
         return {
             literal: str,
             value: value,
@@ -1001,6 +1032,61 @@ parseStatement: true, parseSourceElement: true */
             token.type === Token.Keyword ||
             token.type === Token.BooleanLiteral ||
             token.type === Token.NullLiteral;
+    }
+
+    function advanceSlash() {
+        var prevToken,
+            checkToken;
+        // Using the following algorithm:
+        // https://github.com/mozilla/sweet.js/wiki/design
+        prevToken = extra.tokens[extra.tokens.length - 1];
+        if (!prevToken) {
+            // Nothing before that: it cannot be a division.
+            return scanRegExp();
+        }
+        if (prevToken.type === "Punctuator") {
+            if (prevToken.value === ")") {
+                checkToken = extra.tokens[extra.openParenToken - 1];
+                if (checkToken &&
+                        checkToken.type === "Keyword" &&
+                        (checkToken.value === "if" ||
+                         checkToken.value === "while" ||
+                         checkToken.value === "for" ||
+                         checkToken.value === "with")) {
+                    return scanRegExp();
+                }
+                return scanPunctuator();
+            }
+            if (prevToken.value === "}") {
+                // Dividing a function by anything makes little sense,
+                // but we have to check for that.
+                if (extra.openCurlyToken < 0) {
+                    return scanPunctuator();
+                }
+                if (extra.tokens[extra.openCurlyToken - 3] &&
+                        extra.tokens[extra.openCurlyToken - 3].type === "Keyword") {
+                    checkToken = extra.tokens[extra.openCurlyToken - 4];
+                } else if (extra.tokens[extra.openCurlyToken - 4] &&
+                        extra.tokens[extra.openCurlyToken - 4].type === "Keyword") {
+                    checkToken = extra.tokens[extra.openCurlyToken - 5];
+                } else {
+                    return scanPunctuator();
+                }
+                // checkToken determines whether the function is
+                // a declaration or an expression.
+                if (FnExprTokens.indexOf(checkToken.value) >= 0) {
+                    // It is an expression.
+                    return scanPunctuator();
+                }
+                // It is a declaration.
+                return scanRegExp();
+            }
+            return scanRegExp();
+        }
+        if (prevToken.type === "Keyword") {
+            return scanRegExp();
+        }
+        return scanPunctuator();
     }
 
     function advance() {
@@ -1044,6 +1130,11 @@ parseStatement: true, parseSourceElement: true */
 
         if (isDecimalDigit(ch)) {
             return scanNumericLiteral();
+        }
+
+        // Slash (/) char #47 can also start a regex.
+        if (extra.tokenize && ch === 47) {
+            return advanceSlash();
         }
 
         return scanPunctuator();
@@ -3310,22 +3401,24 @@ parseStatement: true, parseSourceElement: true */
             column: index - lineStart
         };
 
-        // Pop the previous token, which is likely '/' or '/='
-        if (extra.tokens.length > 0) {
-            token = extra.tokens[extra.tokens.length - 1];
-            if (token.range[0] === pos && token.type === 'Punctuator') {
-                if (token.value === '/' || token.value === '/=') {
-                    extra.tokens.pop();
+        if (!extra.tokenize) {
+            // Pop the previous token, which is likely '/' or '/='
+            if (extra.tokens.length > 0) {
+                token = extra.tokens[extra.tokens.length - 1];
+                if (token.range[0] === pos && token.type === 'Punctuator') {
+                    if (token.value === '/' || token.value === '/=') {
+                        extra.tokens.pop();
+                    }
                 }
             }
-        }
 
-        extra.tokens.push({
-            type: 'RegularExpression',
-            value: regex.literal,
-            range: [pos, index],
-            loc: loc
-        });
+            extra.tokens.push({
+                type: 'RegularExpression',
+                value: regex.literal,
+                range: [pos, index],
+                loc: loc
+            });
+        }
 
         return regex;
     }
@@ -3722,6 +3815,94 @@ parseStatement: true, parseSourceElement: true */
         return result;
     }
 
+    function tokenize(code, options) {
+        var toString,
+            token,
+            tokens;
+
+        toString = String;
+        if (typeof code !== 'string' && !(code instanceof String)) {
+            code = toString(code);
+        }
+
+        delegate = SyntaxTreeDelegate;
+        source = code;
+        index = 0;
+        lineNumber = (source.length > 0) ? 1 : 0;
+        lineStart = 0;
+        length = source.length;
+        lookahead = null;
+        state = {
+            allowIn: true,
+            labelSet: {},
+            inFunctionBody: false,
+            inIteration: false,
+            inSwitch: false
+        };
+
+        extra = {};
+
+        // Options matching.
+        options = options || {};
+
+        // Of course we collect tokens here.
+        options.tokens = true;
+        extra.tokens = [];
+        extra.tokenize = true;
+        // The following two fields are necessary to compute the Regex tokens.
+        extra.openParenToken = -1;
+        extra.openCurlyToken = -1;
+
+        extra.range = (typeof options.range === 'boolean') && options.range;
+        extra.loc = (typeof options.loc === 'boolean') && options.loc;
+
+        if (typeof options.comment === 'boolean' && options.comment) {
+            extra.comments = [];
+        }
+        if (typeof options.tolerant === 'boolean' && options.tolerant) {
+            extra.errors = [];
+        }
+
+        if (length > 0) {
+            if (typeof source[0] === 'undefined') {
+                // Try first to convert to a string. This is good as fast path
+                // for old IE which understands string indexing for string
+                // literals only and not for string object.
+                if (code instanceof String) {
+                    source = code.valueOf();
+                }
+            }
+        }
+
+        patch();
+
+        try {
+            peek();
+            if (lookahead.type === Token.EOF) {
+                return extra.tokens;
+            }
+
+            token = lex();
+            while (lookahead.type !== Token.EOF) {
+                try {
+                    token = lex();
+                } catch (lexError) {
+                    token = lookahead;
+                    break;
+                }
+            }
+
+            filterTokenLocation();
+        } catch (e) {
+            throw e;
+        } finally {
+            unpatch();
+            tokens = extra.tokens;
+            extra = {};
+        }
+        return tokens;
+    }
+
     function parse(code, options) {
         var program, toString;
 
@@ -3810,6 +3991,8 @@ parseStatement: true, parseSourceElement: true */
 
     // Sync with package.json and component.json.
     exports.version = '1.1.0-dev';
+
+    exports.tokenize = tokenize;
 
     exports.parse = parse;
 

--- a/test/test.js
+++ b/test/test.js
@@ -18139,6 +18139,78 @@ var testFixture = {
             }
         },
 
+        'tokenize()': {
+          call: 'tokenize',
+          args: [],
+          result: [{
+            type: 'Identifier',
+            value: 'undefined'
+          }]
+        },
+
+        'tokenize(null)': {
+          call: 'tokenize',
+          args: [null],
+          result: [{
+            type: 'Null',
+            value: 'null'
+          }]
+        },
+
+        'tokenize(42)': {
+          call: 'tokenize',
+          args: [42],
+          result: [{
+            type: 'Numeric',
+            value: '42'
+          }]
+        },
+
+        'tokenize(true)': {
+          call: 'tokenize',
+          args: [true],
+          result: [{
+            type: 'Boolean',
+            value: 'true'
+          }]
+        },
+
+        'tokenize(undefined)': {
+          call: 'tokenize',
+          args: [void 0],
+          result: [{
+            type: 'Identifier',
+            value: 'undefined'
+          }]
+        },
+
+        'tokenize(new String("test"))': {
+          call: 'tokenize',
+          args: [new String('test')],
+          result: [{
+            type: 'Identifier',
+            value: 'test'
+          }]
+        },
+
+        'tokenize(new Number(42))': {
+          call: 'tokenize',
+          args: [new Number(42)],
+          result: [{
+            type: 'Numeric',
+            value: '42'
+          }]
+        },
+
+        'tokenize(new Boolean(true))': {
+          call: 'tokenize',
+          args: [new Boolean(true)],
+          result: [{
+            type: 'Boolean',
+            value: 'true'
+          }]
+        },
+
         'Syntax': {
             property: 'Syntax',
             result: {


### PR DESCRIPTION
This adds a `tokenize(code, options)` function to the exported object.

It uses the same API as when `options.tokens` is set.

It also uses Tim Disney's algorithm documented here:
https://github.com/mozilla/sweet.js/wiki/design

http://code.google.com/p/esprima/issues/detail?id=398
