### PR TITLE
Fix \v being treated as v in IE < 9

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -869,7 +869,7 @@ parseStatement: true, parseSourceElement: true */
                         str += '\f';
                         break;
                     case 'v':
-                        str += '\v';
+                        str += '\x0B';
                         break;
 
                     default:

--- a/test/test.js
+++ b/test/test.js
@@ -4511,7 +4511,7 @@ var testFixture = {
             type: 'ExpressionStatement',
             expression: {
                 type: 'Literal',
-                value: '\n\r\t\v\b\f\\\'"\x00',
+                value: '\n\r\t\x0B\b\f\\\'"\x00',
                 raw: '"\\n\\r\\t\\v\\b\\f\\\\\\\'\\"\\0"',
                 range: [0, 22],
                 loc: {


### PR DESCRIPTION
What steps will reproduce the problem?
1. Using esprima on IE < 9.
2. Parsing a string literal containing \v

What is the expected output?
\v

What do you see instead?
v

I actually haven't tested this as the test suite doesn't work in IE. However the problem is documented here http://mathiasbynens.be/notes/javascript-escapes

Mathias Bynens originally found this bug in my Lua parser.
Discussion on luaparse: http://goo.gl/nmoLS
Fix on luaparse: http://goo.gl/v7nxL
Uglify2 also does this: http://goo.gl/xibiK
