### PR TITLE
Add support for harmony class static member functions

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4235,6 +4235,12 @@ parseYieldExpression: true
             expect(')');
             return delegate.createMethodDefinition('set', key, parsePropertyFunction({ params: param, generator: false, name: token }));
         }
+        if (token.value === 'static' && !match('(')) {
+            key = parseObjectPropertyKey();
+            expect('(');
+            expect(')');
+            return delegate.createMethodDefinition('static', key, parsePropertyFunction({ generator: false }));
+        }
         return delegate.createMethodDefinition('', key, parsePropertyMethodFunction({ generator: false }));
     }
 

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -5704,6 +5704,144 @@ var harmonyTestFixture = {
                 end: { line: 1, column: 51 }
             },
             comments: []
+        },
+
+        'class A {static foo() {}}': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7}
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [{
+                    type: 'MethodDefinition',
+                    key: {
+                        type: 'Identifier',
+                        name: 'foo',
+                        range: [16, 19],
+                        loc: {
+                            start: { line: 1, column: 16 },
+                            end: { line: 1, column: 19 }
+                        }
+                    },
+                    value: {
+                        type: 'FunctionExpression',
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            type: 'BlockStatement',
+                            body: [],
+                            range: [22, 24],
+                            loc: {
+                                start: { line: 1, column: 22 },
+                                end: { line: 1, column: 24}
+                            }
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false,
+                        range: [22, 24],
+                        loc: {
+                            start: { line: 1, column: 22 },
+                            end: { line: 1, column: 24 }
+                        }
+                    },
+                    kind: 'static',
+                    range: [9, 24],
+                    loc: {
+                        start: { line: 1, column: 9 },
+                        end: { line: 1, column: 24 }
+                    }
+                }],
+                range: [8, 25],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 25 }
+                }
+            },
+            range: [0, 25],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 25 }
+            }
+        },
+
+        'class A {static() {}}': {
+            type: 'ClassDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'A',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            superClass: null,
+            body: {
+                type: 'ClassBody',
+                body: [
+                    {
+                        type: 'MethodDefinition',
+                        key: {
+                            type: 'Identifier',
+                            name: 'static',
+                            range: [9, 15],
+                            loc: {
+                                start: { line: 1, column: 9 },
+                                end: { line: 1, column: 15 }
+                            }
+                        },
+                        value: {
+                            type: 'FunctionExpression',
+                            id: null,
+                            params: [],
+                            defaults: [],
+                            body: {
+                                type: 'BlockStatement',
+                                body: [],
+                                range: [18, 20],
+                                loc: {
+                                    start: { line: 1, column: 18 },
+                                    end: { line: 1, column: 20 }
+                                }
+                            },
+                            rest: null,
+                            generator: false,
+                            expression: false,
+                            range: [18, 20],
+                            loc: {
+                                start: { line: 1, column: 18 },
+                                end: { line: 1, column: 20 }
+                            }
+                        },
+                        kind: '',
+                        range: [9, 20],
+                        loc: {
+                            start: { line: 1, column: 9 },
+                            end: { line: 1, column: 20 }
+                        }
+                    }
+                ],
+                range: [8, 21],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 21 }
+                }
+            },
+            range: [0, 21],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 21 }
+            }
         }
 
     },


### PR DESCRIPTION
Support for ES6 class static methods was added to the spec draft on March 8:
http://wiki.ecmascript.org/lib/exe/fetch.php?id=harmony%3Aspecification_drafts&cache=cache&media=harmony:working_draft_ecma-262_edition_6_03-08-13-rev14markup.pdf

This adds support for a static token before class methods by adding a new
`kind` value of "static" in the Syntax.MethodDefiniton node interface.

I've added a couple of new tests and verified that all tests still pass.
I've also confirmed that running the benchmark suite results in no significant
perf regressions.

https://code.google.com/p/esprima/issues/detail?id=406
