### PR TITLE
Performance improvement

### DIFF
--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -222,7 +222,7 @@ if (typeof window !== 'undefined') {
                 window.tree = [];
 
                 benchmark = new window.Benchmark(test, function (o) {
-                    var syntax = window.esprima.parse(source, {loc: true});
+                    var syntax = window.esprima.parse(source);
                     window.tree.push(syntax.body.length);
                 }, {
                     'onComplete': function () {


### PR DESCRIPTION
## Improvement on `filterGroup`

As I profiled in Chrome, the most time consuming part for parsing with location information is the `filterGroup` function.
Currently this function will traverse the AST and make a deep copy. This is super slow. Improved to remove `groupLoc` and `groupRange` without deep copy.
## Remove `createLocationMarker`

Location markers are created to make wrappers for parsing functions. But there is no reason to use nest objects and arrays to do the job. Only there numbers are needed here, the start index, line number and col number.
Location markers never stay beyond function boundary. Simply record numbers as local variables.
## Related feature for testing

To test the performance with location information, I added an option to benchmarks.js.
Now you can call `node test/benchmarks.js quick loc` to run quick fixture with location information. The order of the params doesn't matter.
## Benchmark Results

Old benchmark without location information:

| Library | Size | Time | Variance |
| :-: | --: | --: | --: |
| Underscore 1.4.1 | 39.6 | 3.8 | 0.0 |
| Backbone 0.9.2 | 51.9 | 4.1 | 0.0 |
| CodeMirror 2.34 | 126.5 | 16.8 | 0.8 |
| MooTools 1.4.1 | 151.6 | 21.3 | 0.4 |
| jQuery 1.8.2 | 260.6 | 28.8 | 0.7 |
| jQuery.Mobile 1.2.0 | 286.7 | 27.0 | 2.0 |
| Angular 1.0.2 | 465.1 | 32.9 | 1.3 |
| three.js r51 | 801.6 | 152.5 | 228.3 |
| Total | 2183.6 | 287.2 |  |

Old benchmark with location information:

| Library | Size | Time | Variance |
| :-: | --: | --: | --: |
| Underscore 1.4.1 | 39.6 | 59.3 | 48.8 |
| Backbone 0.9.2 | 51.9 | 63.8 | 42.3 |
| CodeMirror 2.34 | 126.5 | 276.5 | 375.8 |
| MooTools 1.4.1 | 151.6 | 380.8 | 539.7 |
| jQuery 1.8.2 | 260.6 | 467.4 | 966.0 |
| jQuery.Mobile 1.2.0 | 286.7 | 428.0 | 277.7 |
| Angular 1.0.2 | 465.1 | 403.8 | 160.8 |
| three.js r51 | 801.6 | 1835.4 | 1765.6 |
| Total | 2183.6 | 3915.0 |  |

New benchmark without location information:

| Library | Size | Time | Variance |
| :-: | --: | --: | --: |
| Underscore 1.4.1 | 39.6 | 3.5 | 0.0 |
| Backbone 0.9.2 | 51.9 | 3.9 | 0.0 |
| CodeMirror 2.34 | 126.5 | 16.2 | 0.7 |
| MooTools 1.4.1 | 151.6 | 20.9 | 1.0 |
| jQuery 1.8.2 | 260.6 | 30.4 | 3.2 |
| jQuery.Mobile 1.2.0 | 286.7 | 24.9 | 0.5 |
| Angular 1.0.2 | 465.1 | 32.1 | 3.0 |
| three.js r51 | 801.6 | 137.8 | 10.7 |
| Total | 2183.6 | 269.7 (7% faster) |  |

New benchmark with location information:

| Library | Size | Time | Variance |
| :-: | --: | --: | --: |
| Underscore 1.4.1 | 39.6 | 14.2 | 3.0 |
| Backbone 0.9.2 | 51.9 | 15.5 | 0.2 |
| CodeMirror 2.34 | 126.5 | 62.5 | 25.6 |
| MooTools 1.4.1 | 151.6 | 82.7 | 127.6 |
| jQuery 1.8.2 | 260.6 | 121.1 | 175.7 |
| jQuery.Mobile 1.2.0 | 286.7 | 110.3 | 469.7 |
| Angular 1.0.2 | 465.1 | 105.0 | 78.0 |
| three.js r51 | 801.6 | 490.4 | 142.8 |
| Total | 2183.6 | **1001.7 (291% faster)** |  |
