### PR TITLE
Fix array literal/comprehension disambiguation bug

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2203,8 +2203,8 @@ parseYieldExpression: true
 
         expect('[');
         while (!match(']')) {
-            switch (lookahead.value) {
-            case 'for':
+            if (lookahead.value === 'for' &&
+                    lookahead.type === Token.Keyword) {
                 if (!possiblecomprehension) {
                     throwError({}, Messages.ComprehensionError);
                 }
@@ -2216,8 +2216,8 @@ parseYieldExpression: true
                     throwError({}, Messages.ComprehensionError);
                 }
                 blocks.push(tmp);
-                break;
-            case 'if':
+            } else if (lookahead.value === 'if' &&
+                           lookahead.type === Token.Keyword) {
                 if (!possiblecomprehension) {
                     throwError({}, Messages.ComprehensionError);
                 }
@@ -2225,13 +2225,12 @@ parseYieldExpression: true
                 expect('(');
                 filter = parseExpression();
                 expect(')');
-                break;
-            case ',':
+            } else if (lookahead.value === ',' &&
+                           lookahead.type === Token.Punctuator) {
                 possiblecomprehension = false; // no longer allowed.
                 lex();
                 elements.push(null);
-                break;
-            default:
+            } else {
                 tmp = parseSpreadOrAssignmentExpression();
                 elements.push(tmp);
                 if (tmp && tmp.type === Syntax.SpreadElement) {

--- a/test/test.js
+++ b/test/test.js
@@ -694,6 +694,60 @@ var testFixture = {
             }
         },
 
+        'x = [ "finally", "for" ]': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'x',
+                    range: [0, 1],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 1 }
+                    }
+                },
+                right: {
+                    type: 'ArrayExpression',
+                    elements: [{
+                        type: 'Literal',
+                        value: 'finally',
+                        raw: '"finally"',
+                        range: [6, 15],
+                        loc: {
+                            start: { line: 1, column: 6 },
+                            end: { line: 1, column: 15 }
+                        }
+                    }, {
+                        type: 'Literal',
+                        value: 'for',
+                        raw: '"for"',
+                        range: [17, 22],
+                        loc: {
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 22 }
+                        }
+                    }],
+                    range: [4, 24],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 24 }
+                    }
+                },
+                range: [0, 24],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 24 }
+                }
+            },
+            range: [0, 24],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 24 }
+            }
+        },
+
         '日本語 = []': {
             type: 'ExpressionStatement',
             expression: {
@@ -908,8 +962,79 @@ var testFixture = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 7 }
             }
-        }
+        },
 
+        '[",", "second"]': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'ArrayExpression',
+                elements: [{
+                    type: 'Literal',
+                    value: ',',
+                    raw: '","',
+                    range: [1, 4],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 4 }
+                    }
+                }, {
+                    type: 'Literal',
+                    value: 'second',
+                    raw: '"second"',
+                    range: [6, 14],
+                    loc: {
+                        start: { line: 1, column: 6 },
+                        end: { line: 1, column: 14 }
+                    }
+                }],
+                range: [0, 15],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 15 }
+                }
+            },
+            range: [0, 15],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 15 }
+            }
+        },
+
+        '["notAToken", "if"]': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'ArrayExpression',
+                elements: [{
+                    type: 'Literal',
+                    value: 'notAToken',
+                    raw: '"notAToken"',
+                    range: [1, 12],
+                    loc: {
+                        start: { line: 1, column: 1 },
+                        end: { line: 1, column: 12 }
+                    }
+                }, {
+                    type: 'Literal',
+                    value: 'if',
+                    raw: '"if"',
+                    range: [14, 18],
+                    loc: {
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 18 }
+                    }
+                }],
+                range: [0, 19],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 19 }
+                }
+            },
+            range: [0, 19],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 19 }
+            }
+        }
     },
 
     'Object Initializer': {
@@ -22195,4 +22320,5 @@ var testFixture = {
 
     }
 };
+
 


### PR DESCRIPTION
Fix array literal/comprehension disambiguation bug

Parsing "var arrayLit = ['notKeyword', 'for', 'otherStuff'];" will fail because the parser sees a value of 'for' when it gets to the second string literal, and does not verify that it is a Keyword token (and not a StringLiteral).

This fixes it by verifying that the token is not StringLiteral

Perf and coverage runners suggest no regressions

https://code.google.com/p/esprima/issues/detail?id=415
