### PR TITLE
Always specify prefix in UnaryExpression node

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1475,7 +1475,8 @@ parseStatement: true, parseSourceElement: true */
             return {
                 type: Syntax.UnaryExpression,
                 operator: operator,
-                argument: argument
+                argument: argument,
+                prefix: true
             };
         },
 

--- a/test/reflect.js
+++ b/test/reflect.js
@@ -88,7 +88,7 @@ function genFunExpr(id, args, body) { return Pattern({ type: "FunctionExpression
                                               expression: false
                                               }) }
 
-function unExpr(op, arg) { return Pattern({ type: "UnaryExpression", operator: op, argument: arg }) }
+function unExpr(op, arg) { return Pattern({ type: "UnaryExpression", operator: op, argument: arg, prefix: true }) }
 function binExpr(op, left, right) { return Pattern({ type: "BinaryExpression", operator: op, left: left, right: right }) }
 function aExpr(op, left, right) { return Pattern({ type: "AssignmentExpression", operator: op, left: left, right: right }) }
 function updExpr(op, arg, prefix) { return Pattern({ type: "UpdateExpression", operator: op, argument: arg, prefix: prefix }) }

--- a/test/test.js
+++ b/test/test.js
@@ -6943,6 +6943,7 @@ var testFixture = {
                         end: { line: 1, column: 2 }
                     }
                 },
+                prefix: true,
                 range: [0, 2],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -6970,6 +6971,7 @@ var testFixture = {
                         end: { line: 1, column: 2 }
                     }
                 },
+                prefix: true,
                 range: [0, 2],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -6997,6 +6999,7 @@ var testFixture = {
                         end: { line: 1, column: 2 }
                     }
                 },
+                prefix: true,
                 range: [0, 2],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -7024,6 +7027,7 @@ var testFixture = {
                         end: { line: 1, column: 2 }
                     }
                 },
+                prefix: true,
                 range: [0, 2],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -7051,6 +7055,7 @@ var testFixture = {
                         end: { line: 1, column: 6 }
                     }
                 },
+                prefix: true,
                 range: [0, 6],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -7078,6 +7083,7 @@ var testFixture = {
                         end: { line: 1, column: 8 }
                     }
                 },
+                prefix: true,
                 range: [0, 8],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -7105,6 +7111,7 @@ var testFixture = {
                         end: { line: 1, column: 8 }
                     }
                 },
+                prefix: true,
                 range: [0, 8],
                 loc: {
                     start: { line: 1, column: 0 },
@@ -19711,6 +19718,7 @@ var testFixture = {
                             end: { line: 1, column: 22 }
                         }
                     },
+                    prefix: true,
                     range: [14, 22],
                     loc: {
                         start: { line: 1, column: 14 },


### PR DESCRIPTION
Prefix is specified in only half of the cases. I think it should be either removed or used for every UnaryExpression.

Thoughts?
