### PR TITLE
Performance improvement from introducing a LocationMarker object type on the harmony branch

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4844,11 +4844,9 @@ parseYieldExpression: true
         extra.tokens = tokens;
     }
 
-    function createLocationMarker() {
-        var marker = {};
-
-        marker.range = [index, index];
-        marker.loc = {
+    function LocationMarker() {
+        this.range = [index, index];
+        this.loc = {
             start: {
                 line: lineNumber,
                 column: index - lineStart
@@ -4858,14 +4856,18 @@ parseYieldExpression: true
                 column: index - lineStart
             }
         };
+    }
 
-        marker.end = function () {
+    LocationMarker.prototype = {
+        constructor: LocationMarker,
+
+        end: function () {
             this.range[1] = index;
             this.loc.end.line = lineNumber;
             this.loc.end.column = index - lineStart;
-        };
+        },
 
-        marker.applyGroup = function (node) {
+        applyGroup: function (node) {
             if (extra.range) {
                 node.groupRange = [this.range[0], this.range[1]];
             }
@@ -4882,9 +4884,9 @@ parseYieldExpression: true
                 };
                 node = delegate.postProcess(node);
             }
-        };
+        },
 
-        marker.apply = function (node) {
+        apply: function (node) {
             var nodeType = typeof node;
             assert(nodeType === "object",
                 "Applying location marker to an unexpected node type: " +
@@ -4906,9 +4908,11 @@ parseYieldExpression: true
                 };
                 node = delegate.postProcess(node);
             }
-        };
+        }
+    };
 
-        return marker;
+    function createLocationMarker() {
+        return new LocationMarker();
     }
 
     function trackGroupExpression() {


### PR DESCRIPTION
This change gives a noticeable performance improvement on the harmony branch, when either the `loc` or the `range` parsing options are enabled.

Note that `test/benchmarks.js` does not enable either of these options, and so those benchmarks don't show any improvement with this patch applied.

When I run `node test/runner.js`, I see a consistent 38% decrease in running time (from ~1100ms to ~680ms on my machine).

When I run the same test suite in Chrome 28, the running time drops from ~1700ms to ~1200ms (a 30% decrease).

When I run the test suite in Firefox 21, the running time drops from ~2300ms to ~2000ms (a 13% decrease).

The performance win is attributable to inheriting the `end`, `applyGroup`, and `apply` methods from `LocationMarker.prototype` instead of redefining them for each instance.
