### PR TITLE
Do not distribute tests via npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,5 @@
 /assets/
 /coverage/
 /demo/
-/test/3rdparty
+/test/
 /tools/


### PR DESCRIPTION
I use browserify. Of its 13 MB footprint, the transient dependecy Esprima takes 3 MB for tests alone. They need not be distributed via npm.
