### PR TITLE
Parsing empty switch contains 'cases' key

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3000,12 +3000,12 @@ parseStatement: true, parseSourceElement: true */
 
         expect('{');
 
+        cases = [];
+
         if (match('}')) {
             lex();
-            return delegate.createSwitchStatement(discriminant);
+            return delegate.createSwitchStatement(discriminant, cases);
         }
-
-        cases = [];
 
         oldInSwitch = state.inSwitch;
         state.inSwitch = true;

--- a/test/test.js
+++ b/test/test.js
@@ -13703,6 +13703,7 @@ var testFixture = {
                     end: { line: 1, column: 9 }
                 }
             },
+            cases:[],
             range: [0, 13],
             loc: {
                 start: { line: 1, column: 0 },


### PR DESCRIPTION
SpiderMonkey and the Parser API defined 'cases' to be in the
SwitchStatement production.

https://code.google.com/p/esprima/issues/detail?id=436

Here is the SpiderMonkey output:

``` javascript
> Reflect.parse("switch(foo) {}")
({loc:{start:{line:1, column:0}, end:{line:1, column:14}, source:null}, type:"Program", body:[{loc:{start:{line:1, column:0}, end:{line:1, column:14}, source:null}, type:"SwitchStatement", discriminant:{loc:{start:{line:1, column:7}, end:{line:1, column:10}, source:null}, type:"Identifier", name:"foo"}, cases:[], lexical:false}]})
```

This came from a PR [here](https://github.com/mduvall/eslint/commit/2cb97bac3476332413e50cf4f40b413ccf176d8f) and it seemed better to handle it at the parser level. Let me know what I can do to get this in, thanks!
