### PR TITLE
Implement tokenRange

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1368,6 +1368,9 @@ parseStatement: true, parseSourceElement: true */
             if (extra.range) {
                 state.markerStack.push(index);
             }
+            if (extra.tokenRange) {
+                state.markerStack.push(extra.tokens.length ? extra.tokens.length - 1 : 0);
+            }
         },
 
         processComment: function (node) {
@@ -1410,6 +1413,9 @@ parseStatement: true, parseSourceElement: true */
         },
 
         markEnd: function (node) {
+            if (extra.tokenRange) {
+                node.tokenRange = [ state.markerStack.pop(), extra.tokens.length];
+            }
             if (extra.range) {
                 node.range = [state.markerStack.pop(), index];
             }
@@ -1433,7 +1439,10 @@ parseStatement: true, parseSourceElement: true */
         },
 
         markEndIf: function (node) {
-            if (node.range || node.loc) {
+            if (node.range || node.loc || node.tokenRange) {
+                if (node.tokenRange) {
+                    state.markerStack.pop();
+                }
                 if (extra.loc) {
                     state.markerStack.pop();
                     state.markerStack.pop();
@@ -3670,6 +3679,7 @@ parseStatement: true, parseSourceElement: true */
 
         extra.range = (typeof options.range === 'boolean') && options.range;
         extra.loc = (typeof options.loc === 'boolean') && options.loc;
+        extra.tokenRange = (typeof options.tokenRange === 'boolean') && options.tokenRange;
 
         if (typeof options.comment === 'boolean' && options.comment) {
             extra.comments = [];
@@ -3758,6 +3768,7 @@ parseStatement: true, parseSourceElement: true */
             extra.range = (typeof options.range === 'boolean') && options.range;
             extra.loc = (typeof options.loc === 'boolean') && options.loc;
             extra.attachComment = (typeof options.attachComment === 'boolean') && options.attachComment;
+            extra.tokenRange = (typeof options.tokenRange === 'boolean') && options.tokenRange;
 
             if (extra.loc && options.source !== null && options.source !== undefined) {
                 extra.source = toString(options.source);

--- a/test/runner.js
+++ b/test/runner.js
@@ -95,6 +95,7 @@ function testParse(esprima, code, syntax) {
 
     options = {
         comment: (typeof syntax.comments !== 'undefined'),
+        tokenRange: (typeof syntax.tokenRange !== 'undefined'),
         range: true,
         loc: true,
         tokens: (typeof syntax.tokens !== 'undefined'),

--- a/test/test.js
+++ b/test/test.js
@@ -39,18 +39,21 @@ var testFixture = {
                 type: 'ExpressionStatement',
                 expression: {
                     type: 'ThisExpression',
+                    tokenRange: [0, 1],
                     range: [0, 4],
                     loc: {
                         start: { line: 1, column: 0 },
                         end: { line: 1, column: 4 }
                     }
                 },
+                tokenRange: [0, 1],
                 range: [0, 5],
                 loc: {
                     start: { line: 1, column: 0 },
                     end: { line: 2, column: 0 }
                 }
             }],
+            tokenRange: [0, 1],
             range: [0, 5],
             loc: {
                 start: { line: 1, column: 0 },
@@ -75,18 +78,21 @@ var testFixture = {
                     type: 'Literal',
                     value: null,
                     raw: 'null',
+                    tokenRange: [0, 1],
                     range: [0, 4],
                     loc: {
                         start: { line: 1, column: 0 },
                         end: { line: 1, column: 4 }
                     }
                 },
+                tokenRange: [0, 1],
                 range: [0, 5],
                 loc: {
                     start: { line: 1, column: 0 },
                     end: { line: 2, column: 0 }
                 }
             }],
+            tokenRange: [0, 1],
             range: [0, 5],
             loc: {
                 start: { line: 1, column: 0 },
@@ -111,18 +117,21 @@ var testFixture = {
                     type: 'Literal',
                     value: 42,
                     raw: '42',
+                    tokenRange: [0, 1],
                     range: [5, 7],
                     loc: {
                         start: { line: 2, column: 4 },
                         end: { line: 2, column: 6 }
                     }
                 },
+                tokenRange: [0, 1],
                 range: [5, 9],
                 loc: {
                     start: { line: 2, column: 4 },
                     end: { line: 4, column: 0 }
                 }
             }],
+            tokenRange: [0, 1],
             range: [5, 9],
             loc: {
                 start: { line: 2, column: 4 },


### PR DESCRIPTION
This is a first attempt at creating something workable for:

https://code.google.com/p/esprima/issues/detail?id=437

The basic idea is to add a `tokenRange` property to each AST node that contains the index of the first token representing the node and the index before the last token representing the node.

Really just looking for feedback if this is worthwhile an attempt or not. Not completely done (tests missing).
