### PR TITLE
Support `<!--` comment syntax

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1,6 +1,7 @@
 /*
   Copyright (C) 2013 Ariya Hidayat <ariya.hidayat@gmail.com>
   Copyright (C) 2013 Thaddee Tyl <thaddee.tyl@gmail.com>
+  Copyright (C) 2013 Mathias Bynens <mathias@qiwi.be>
   Copyright (C) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>
   Copyright (C) 2012 Mathias Bynens <mathias@qiwi.be>
   Copyright (C) 2012 Joost-Wim Boekesteijn <joost-wim@boekesteijn.nl>
@@ -481,6 +482,16 @@ parseStatement: true, parseSourceElement: true */
                     ++index;
                     ++index;
                     skipMultiLineComment();
+                } else {
+                    break;
+                }
+            } else if (ch === 60) { // 60 is '<'
+                if (source.slice(index + 1, index + 4) === '!--') {
+                    ++index; // `<`
+                    ++index; // `!`
+                    ++index; // `-`
+                    ++index; // `-`
+                    skipSingleLineComment();
                 } else {
                     break;
                 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 /*
+  Copyright (C) 2013 Mathias Bynens <mathias@qiwi.be>
   Copyright (C) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>
   Copyright (C) 2012 Joost-Wim Boekesteijn <joost-wim@boekesteijn.nl>
   Copyright (C) 2012 Yusuke Suzuki <utatane.tea@gmail.com>
@@ -22789,6 +22790,39 @@ var testFixture = {
                 lineNumber: 1,
                 column: 7,
                 message: 'Error: Line 1: Invalid left-hand side in for-in'
+            }]
+        },
+
+        '<!-- foo': {
+          type: 'Program',
+          body: [],
+          comments: [{
+              type: 'Line',
+              value: ' foo'
+          }]
+        },
+
+        'var x = 1<!--foo': {
+            type: 'Program',
+            body: [{
+                type: 'VariableDeclaration',
+                declarations: [{
+                    type: 'VariableDeclarator',
+                    id: {
+                        type: 'Identifier',
+                        name: 'x'
+                    },
+                    init: {
+                        type: 'Literal',
+                        value: 1,
+                        raw: '1'
+                    }
+                }],
+                kind: 'var'
+            }],
+            comments: [{
+                type: 'Line',
+                value: 'foo'
             }]
         }
 


### PR DESCRIPTION
This partially fixes https://code.google.com/p/esprima/issues/detail?id=451.

(After this patch, only the `-->` syntax is left, but that one is a bit trickier (as it [only takes effect when it’s the first token on the line, optionally preceeded by only whitespace or multiline comments](http://javascript.spec.whatwg.org/#comment-syntax)).)
