### PR TITLE
Include LineTerminatorSequence in TemplateElement cooked values

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1195,6 +1195,7 @@ parseYieldExpression: true
                 if (ch ===  '\r' && source[index] === '\n') {
                     ++index;
                 }
+                cooked += '\n';
             } else {
                 cooked += ch;
             }

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -679,7 +679,7 @@ var harmonyTestFixture = {
                     type: 'TemplateElement',
                     value: {
                         raw: '\n\r\n',
-                        cooked: ''
+                        cooked: '\n\n'
                     },
                     tail: true,
                     range: [0, 5],


### PR DESCRIPTION
The 2013-09-27 draft of the ES6 draft, section 11.8.6, now says "The TV of TemplateCharacter :: LineTerminatorSequence is the TRV of LineTerminatorSequence."

https://code.google.com/p/esprima/issues/detail?id=456
