### PR TITLE
Make tools/generate-test-fixture.js output "proper" JSON by quoting obje...

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "complexity-report": "~0.6.1",
         "regenerate": "~0.5.4",
         "unicode-6.3.0": "~0.1.0",
-        "json-diff": "~0.3.1"
+        "json-diff": "~0.3.1",
+        "optimist": "~0.6.0"
     },
     "keywords": [
         "ast",


### PR DESCRIPTION
...ct keys

Currently tools/generate-test-fixture.js outputs JSON objects whose keys are not
double-quoted. This changes the tool to always double-quote object keys thus
resulting in the ability to pipe the output of generate-test-fixture.js to other
tools that expect valie JSON.

https://code.google.com/p/esprima/issues/detail?id=461
