### PR TITLE
Fix for tokenizing and regex

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1118,7 +1118,6 @@ parseStatement: true, parseSourceElement: true */
             throwError({}, Messages.InvalidRegExp);
         }
 
-        peek();
 
 
         if (extra.tokenize) {
@@ -2179,6 +2178,7 @@ parseStatement: true, parseSourceElement: true */
             } else {
                 expr = delegate.createLiteral(scanRegExp());
             }
+            peek();
         }
 
         if (expr) {

--- a/test/test.js
+++ b/test/test.js
@@ -19833,24 +19833,6 @@ var testFixture = {
                 }
             },
             {
-                "type": "Punctuator",
-                "value": ")",
-                "range": [
-                    13,
-                    14
-                ],
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 13
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 14
-                    }
-                }
-            },
-            {
                 "type": "RegularExpression",
                 "value": "/42/",
                 "range": [
@@ -19976,24 +19958,6 @@ var testFixture = {
                     "end": {
                         "line": 1,
                         "column": 12
-                    }
-                }
-            },
-            {
-                "type": "Punctuator",
-                "value": "}",
-                "range": [
-                    18,
-                    19
-                ],
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 18
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 19
                     }
                 }
             },


### PR DESCRIPTION
When running tokenize on code with regular expression literals the order of tokens would sometimes be off and extra tokens inserted. This was due to peek being called before scanRegExp finished adding
the literal to extra.tokens.

http://code.google.com/p/esprima/issues/detail?id=446
