### PR TITLE
Rename ArrowFunctionExpression to ArrowExpression

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -118,7 +118,7 @@ parseYieldExpression: true
     Syntax = {
         ArrayExpression: 'ArrayExpression',
         ArrayPattern: 'ArrayPattern',
-        ArrowFunctionExpression: 'ArrowFunctionExpression',
+        ArrowExpression: 'ArrowExpression',
         AssignmentExpression: 'AssignmentExpression',
         BinaryExpression: 'BinaryExpression',
         BlockStatement: 'BlockStatement',
@@ -1895,9 +1895,9 @@ parseYieldExpression: true
             };
         },
 
-        createArrowFunctionExpression: function (params, defaults, body, rest, expression) {
+        createArrowExpression: function (params, defaults, body, rest, expression) {
             return {
-                type: Syntax.ArrowFunctionExpression,
+                type: Syntax.ArrowExpression,
                 id: null,
                 params: params,
                 defaults: defaults,
@@ -3009,7 +3009,7 @@ parseYieldExpression: true
         };
     }
 
-    function parseArrowFunctionExpression(options) {
+    function parseArrowExpression(options) {
         var previousStrict, previousYieldAllowed, body;
 
         expect('=>');
@@ -3029,7 +3029,7 @@ parseYieldExpression: true
         strict = previousStrict;
         state.yieldAllowed = previousYieldAllowed;
 
-        return delegate.createArrowFunctionExpression(options.params, options.defaults, body, options.rest, body.type !== Syntax.BlockStatement);
+        return delegate.createArrowExpression(options.params, options.defaults, body, options.rest, body.type !== Syntax.BlockStatement);
     }
 
     function parseAssignmentExpression() {
@@ -3048,7 +3048,7 @@ parseYieldExpression: true
                 if (!match('=>')) {
                     throwUnexpected(lex());
                 }
-                return parseArrowFunctionExpression(params);
+                return parseArrowExpression(params);
             }
         }
 
@@ -3064,7 +3064,7 @@ parseYieldExpression: true
                 params = reinterpretAsCoverFormalsList(expr.expressions);
             }
             if (params) {
-                return parseArrowFunctionExpression(params);
+                return parseArrowExpression(params);
             }
         }
 
@@ -3125,7 +3125,7 @@ parseYieldExpression: true
                 expr = expr.type === Syntax.SequenceExpression ? expr.expressions : expressions;
                 coverFormalsList = reinterpretAsCoverFormalsList(expr);
                 if (coverFormalsList) {
-                    return parseArrowFunctionExpression(coverFormalsList);
+                    return parseArrowExpression(coverFormalsList);
                 }
             }
             throwUnexpected(lex());

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -884,7 +884,7 @@ var harmonyTestFixture = {
         '() => "test"': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [],
                 defaults: [],
@@ -917,7 +917,7 @@ var harmonyTestFixture = {
         'e => "test"': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -958,7 +958,7 @@ var harmonyTestFixture = {
         '(e) => "test"': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -999,7 +999,7 @@ var harmonyTestFixture = {
         '(a, b) => "test"': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1048,7 +1048,7 @@ var harmonyTestFixture = {
         'e => { 42; }': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1105,7 +1105,7 @@ var harmonyTestFixture = {
         '(a, b) => { 42; }': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1170,7 +1170,7 @@ var harmonyTestFixture = {
         '([a, , b]) => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ArrayPattern',
@@ -1227,7 +1227,7 @@ var harmonyTestFixture = {
         '([a.a]) => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ArrayPattern',
@@ -1294,7 +1294,7 @@ var harmonyTestFixture = {
         '(x=1) => x * x': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1362,7 +1362,7 @@ var harmonyTestFixture = {
         'eval => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1404,7 +1404,7 @@ var harmonyTestFixture = {
         'arguments => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1446,7 +1446,7 @@ var harmonyTestFixture = {
         '(a) => 00': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1488,7 +1488,7 @@ var harmonyTestFixture = {
         '(eval, a) => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1538,7 +1538,7 @@ var harmonyTestFixture = {
         '(eval = 10) => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1589,7 +1589,7 @@ var harmonyTestFixture = {
         '(eval, a = 10) => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1647,7 +1647,7 @@ var harmonyTestFixture = {
         '(x => x)': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1687,7 +1687,7 @@ var harmonyTestFixture = {
         'x => y => 42': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1700,7 +1700,7 @@ var harmonyTestFixture = {
                 }],
                 defaults: [],
                 body: {
-                    type: 'ArrowFunctionExpression',
+                    type: 'ArrowExpression',
                     id: null,
                     params: [{
                         type: 'Identifier',
@@ -1750,7 +1750,7 @@ var harmonyTestFixture = {
         '(x) => ((y, z) => (x, y, z))': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -1763,7 +1763,7 @@ var harmonyTestFixture = {
                 }],
                 defaults: [],
                 body: {
-                    type: 'ArrowFunctionExpression',
+                    type: 'ArrowExpression',
                     id: null,
                     params: [{
                         type: 'Identifier',
@@ -1855,7 +1855,7 @@ var harmonyTestFixture = {
                     }
                 },
                 'arguments': [{
-                    type: 'ArrowFunctionExpression',
+                    type: 'ArrowExpression',
                     id: null,
                     params: [],
                     defaults: [],
@@ -1904,7 +1904,7 @@ var harmonyTestFixture = {
                     }
                 },
                 'arguments': [{
-                    type: 'ArrowFunctionExpression',
+                    type: 'ArrowExpression',
                     id: null,
                     params: [{
                         type: 'Identifier',
@@ -10281,7 +10281,7 @@ var harmonyTestFixture = {
         '(...a) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [],
                 defaults: [],
@@ -10320,7 +10320,7 @@ var harmonyTestFixture = {
         '(a, ...b) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -10368,7 +10368,7 @@ var harmonyTestFixture = {
         '({ a }) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ObjectPattern',
@@ -10436,7 +10436,7 @@ var harmonyTestFixture = {
         '({ a }, ...b) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ObjectPattern',
@@ -10511,7 +10511,7 @@ var harmonyTestFixture = {
         '(...[a, b]) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [],
                 defaults: [],
@@ -10566,7 +10566,7 @@ var harmonyTestFixture = {
         '(a, ...[b]) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'Identifier',
@@ -10621,7 +10621,7 @@ var harmonyTestFixture = {
         '({ a: [a, b] }, ...c) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ObjectPattern',
@@ -10712,7 +10712,7 @@ var harmonyTestFixture = {
         '({ a: b, c }, [d, e], ...f) => {}': {
             type: 'ExpressionStatement',
             expression: {
-                type: 'ArrowFunctionExpression',
+                type: 'ArrowExpression',
                 id: null,
                 params: [{
                     type: 'ObjectPattern',
@@ -11948,7 +11948,7 @@ var harmonyTestFixture = {
             index: 34,
             lineNumber: 1,
             column: 35,
-            message: 'Error: Line 1: Parameter name eval or arguments is not allowed in strict mode'            
+            message: 'Error: Line 1: Parameter name eval or arguments is not allowed in strict mode'
         },
 
         '(a, a) => 42': {

--- a/test/test.js
+++ b/test/test.js
@@ -19449,7 +19449,7 @@ var testFixture = {
             result: {
                 ArrayExpression: 'ArrayExpression',
                 ArrayPattern: 'ArrayPattern',
-                ArrowFunctionExpression: 'ArrowFunctionExpression',
+                ArrowExpression: 'ArrowExpression',
                 AssignmentExpression: 'AssignmentExpression',
                 BinaryExpression: 'BinaryExpression',
                 BlockStatement: 'BlockStatement',


### PR DESCRIPTION
The Parser API specifies a node named ArrowExpression, but none named ArrowFunctionExpression. This same change was already made in Constellation/estraverse#16, which is what brought it to my attention.

The issue is at https://code.google.com/p/esprima/issues/detail?id=479
