### PR TITLE
Make npm test work on Windows and ignore node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+node_modules

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "generate-regex": "node tools/generate-identifier-regex.js",
 
         "test": "npm run-script lint && node test/run.js && npm run-script coverage && npm run-script complexity",
-        "lint": "node tools/check-version.js && node_modules/eslint/bin/eslint.js esprima.js && node_modules/jslint/bin/jslint.js esprima.js",
+        "lint": "node tools/check-version.js && node node_modules/eslint/bin/eslint.js esprima.js && node node_modules/jslint/bin/jslint.js esprima.js",
         "coverage": "npm run-script analyze-coverage && npm run-script check-coverage",
         "analyze-coverage": "node node_modules/istanbul/lib/cli.js cover test/runner.js",
         "check-coverage": "node node_modules/istanbul/lib/cli.js check-coverage --statement -8 --branch -19 --function 100",


### PR DESCRIPTION
Addresses:
https://code.google.com/p/esprima/issues/detail?id=490

Also, added `node_modules` to `.gitignore`.
