### PR TITLE
Updated .npmignore to reduce the package size.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 .travis.yml
 CONTRIBUTING.md
 ChangeLog
-LICENSE.BSD
 assets/
 bower.json
 component.json


### PR DESCRIPTION
Current `.npmignore` is outdated and it unnecessarily increases the published package size. For instance, in [ultimate-seed](https://github.com/pilwon/ultimate-seed) project, `node_modules/` takes up **309MB** due to the large number of dependencies and their package size (see pilwon/ultimate-seed#71).

Please double check that I didn't accidentally include core files to `.npmignore`.
