### PR TITLE
Fix the issue when the loc/range would sometimes include a leading white...

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1361,6 +1361,7 @@ parseStatement: true, parseSourceElement: true */
         name: 'SyntaxTree',
 
         markStart: function () {
+            skipComment();
             if (extra.loc) {
                 state.markerStack.push(index - lineStart);
                 state.markerStack.push(lineNumber);
@@ -1993,7 +1994,6 @@ parseStatement: true, parseSourceElement: true */
         var previousStrict, body;
 
         previousStrict = strict;
-        skipComment();
         delegate.markStart();
         body = parseFunctionSourceElements();
         if (first && strict && isRestrictedWord(param[0].name)) {
@@ -2006,7 +2006,6 @@ parseStatement: true, parseSourceElement: true */
     function parseObjectPropertyKey() {
         var token;
 
-        skipComment();
         delegate.markStart();
         token = lex();
 
@@ -2027,7 +2026,6 @@ parseStatement: true, parseSourceElement: true */
         var token, key, id, value, param;
 
         token = lookahead;
-        skipComment();
         delegate.markStart();
 
         if (token.type === Token.Identifier) {
@@ -2617,7 +2615,6 @@ parseStatement: true, parseSourceElement: true */
     function parseBlock() {
         var block;
 
-        skipComment();
         delegate.markStart();
         expect('{');
 
@@ -2633,7 +2630,6 @@ parseStatement: true, parseSourceElement: true */
     function parseVariableIdentifier() {
         var token;
 
-        skipComment();
         delegate.markStart();
         token = lex();
 
@@ -2647,7 +2643,6 @@ parseStatement: true, parseSourceElement: true */
     function parseVariableDeclaration(kind) {
         var init = null, id;
 
-        skipComment();
         delegate.markStart();
         id = parseVariableIdentifier();
 
@@ -2700,7 +2695,6 @@ parseStatement: true, parseSourceElement: true */
     function parseConstLetDeclaration(kind) {
         var declarations;
 
-        skipComment();
         delegate.markStart();
 
         expectKeyword(kind);
@@ -3036,7 +3030,6 @@ parseStatement: true, parseSourceElement: true */
             consequent = [],
             statement;
 
-        skipComment();
         delegate.markStart();
         if (matchKeyword('default')) {
             lex();
@@ -3126,7 +3119,6 @@ parseStatement: true, parseSourceElement: true */
     function parseCatchClause() {
         var param, body;
 
-        skipComment();
         delegate.markStart();
         expectKeyword('catch');
 
@@ -3191,7 +3183,6 @@ parseStatement: true, parseSourceElement: true */
             throwUnexpected(lookahead);
         }
 
-        skipComment();
         delegate.markStart();
 
         if (type === Token.Punctuator) {
@@ -3270,7 +3261,6 @@ parseStatement: true, parseSourceElement: true */
         var sourceElement, sourceElements = [], token, directive, firstRestricted,
             oldLabelSet, oldInIteration, oldInSwitch, oldInFunctionBody;
 
-        skipComment();
         delegate.markStart();
         expect('{');
 
@@ -3383,7 +3373,6 @@ parseStatement: true, parseSourceElement: true */
     function parseFunctionDeclaration() {
         var id, params = [], body, token, stricted, tmp, firstRestricted, message, previousStrict;
 
-        skipComment();
         delegate.markStart();
 
         expectKeyword('function');
@@ -3530,7 +3519,6 @@ parseStatement: true, parseSourceElement: true */
     function parseProgram() {
         var body;
 
-        skipComment();
         delegate.markStart();
         strict = false;
         peek();

--- a/test/test.js
+++ b/test/test.js
@@ -10611,8 +10611,53 @@ var testFixture = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 14 }
             }
+        },
+        'x = (0) ? 1 : 2' : {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'x',
+                    range: [ 0, 1 ],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 1 }
+                    }
+                },
+                right: {
+                    type: 'ConditionalExpression',
+                    test: {
+                        type: 'Literal',
+                        value: 0,
+                        raw: '0',
+                        range: [ 5, 6 ],
+                        loc: { start: { line: 1, column: 5 }, end: { line: 1, column: 6 } }
+                    },
+                    consequent: {
+                        type: 'Literal',
+                        value: 1,
+                        raw: '1',
+                        range: [ 10, 11 ],
+                        loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 11 } }
+                    },
+                    alternate: {
+                        type: 'Literal',
+                        value: 2,
+                        raw: '2',
+                        range: [ 14, 15 ],
+                        loc: { start: { line: 1, column: 14 }, end: { line: 1, column: 15 } }
+                    },
+                    range: [ 4, 15 ],
+                    loc: { start: { line: 1, column: 4 }, end: { line: 1, column: 15 } }
+                },
+                range: [ 0, 15 ],
+                loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 15 } }
+            },
+            range: [ 0, 15 ],
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 15 } }
         }
-
     },
 
     'Assignment Operators': {
@@ -13949,9 +13994,9 @@ var testFixture = {
                                 end: { line: 1, column: 18 }
                             }
                         },
-                        range: [12, 18],
+                        range: [13, 18],
                         loc: {
-                            start: { line: 1, column: 12 },
+                            start: { line: 1, column: 13 },
                             end: { line: 1, column: 18 }
                         }
                     },
@@ -14059,15 +14104,15 @@ var testFixture = {
                                     end: { line: 1, column: 28 }
                                 }
                             },
-                            range: [16, 29],
+                            range: [17, 29],
                             loc: {
-                                start: { line: 1, column: 16 },
+                                start: { line: 1, column: 17 },
                                 end: { line: 1, column: 29 }
                             }
                         },
-                        range: [12, 29],
+                        range: [13, 29],
                         loc: {
-                            start: { line: 1, column: 12 },
+                            start: { line: 1, column: 13 },
                             end: { line: 1, column: 29 }
                         }
                     },
@@ -24257,4 +24302,3 @@ var testFixture = {
 
     }
 };
-


### PR DESCRIPTION
...space.

Summary:https://code.google.com/p/esprima/issues/detail?id=501
markStart() was not always preceded by skipComment(). Moving the
skipComment() inside instead.

Test Plan: npm test
