### PR TITLE
Issue 504: Forgot to recount line start at string literals with escaped new line

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1013,6 +1013,7 @@ parseStatement: true, parseSourceElement: true */
                     if (ch ===  '\r' && source[index] === '\n') {
                         ++index;
                     }
+                    lineStart = index;
                 }
             } else if (isLineTerminator(ch.charCodeAt(0))) {
                 break;

--- a/test/test.js
+++ b/test/test.js
@@ -5786,13 +5786,13 @@ var testFixture = {
                 range: [0, 14],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 2, column: 14 }
+                    end: { line: 2, column: 6 }
                 }
             },
             range: [0, 14],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 2, column: 14 }
+                end: { line: 2, column: 6 }
             }
         },
 
@@ -5976,13 +5976,13 @@ var testFixture = {
                 range: [0, 15],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 2, column: 15 }
+                    end: { line: 2, column: 6 }
                 }
             },
             range: [0, 15],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 2, column: 15 }
+                end: { line: 2, column: 6 }
             }
         },
 


### PR DESCRIPTION
[Issue 504](https://code.google.com/p/esprima/issues/detail?id=504).
New line started but lineStart is not reset.
