### PR TITLE
Use field instead of an array in LocationMarker

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3571,7 +3571,7 @@ parseStatement: true, parseSourceElement: true */
     function LocationMarker() {
         this.startIndex = index;
         this.startLine = lineNumber;
-        this.startColumn = index- lineStart;
+        this.startColumn = index - lineStart;
     }
 
     LocationMarker.prototype = {


### PR DESCRIPTION
A little tweak to avoid bashing GC.

Before:

| Source | Size (KiB) | Time (ms) | Time (ms) | Time (ms) |
| :-: | --: | --: | --: | --: |
| Underscore 1.5.2 | 42.5 | 4.96 ms ± 1.16% | 4.99 ms ± 1.66% | 4.94 ms ± 1.21% |
| Backbone 1.1.0 | 58.7 | 5.22 ms ± 1.03% | 5.30 ms ± 0.77% | 5.16 ms ± 0.82% |
| MooTools 1.4.5 | 156.7 | 43.60 ms ± 3.90% | 43.88 ms ± 3.68% | 43.27 ms ± 3.79% |
| jQuery 1.9.1 | 262.1 | 58.02 ms ± 1.63% | 59.68 ms ± 2.11% | 58.27 ms ± 2.06% |
| YUI 3.12.0 | 330.4 | 45.46 ms ± 1.42% | 45.71 ms ± 1.62% | 45.02 ms ± 1.58% |
| jQuery.Mobile 1.4.2 | 442.2 | 98.91 ms ± 2.35% | 101.79 ms ± 3.45% | 100.41 ms ± 2.88% |
| Angular 1.2.5 | 701.7 | 77.79 ms ± 2.50% | 77.52 ms ± 2.38% | 78.46 ms ± 2.12% |
| Total | 1994.3 | 333.95 | 338.87 | 335.52 |

After:

| Source | Size (KiB) | Time (ms) | Time (ms) | Time (ms) |
| :-: | --: | --: | --: | --: |
| Underscore 1.5.2 | 42.5 | 4.63 ms ± 1.42% | 4.66 ms ± 0.88% | 4.67 ms ± 1.42% |
| Backbone 1.1.0 | 58.7 | 5.08 ms ± 0.97% | 5.07 ms ± 0.52% | 4.98 ms ± 0.55% |
| MooTools 1.4.5 | 156.7 | 37.95 ms ± 6.46% | 36.97 ms ± 6.26% | 35.09 ms ± 6.43% |
| jQuery 1.9.1 | 262.1 | 58.76 ms ± 3.04% | 55.08 ms ± 2.33% | 55.85 ms ± 2.77% |
| YUI 3.12.0 | 330.4 | 34.60 ms ± 5.85% | 32.89 ms ± 5.04% | 34.15 ms ± 6.43% |
| jQuery.Mobile 1.4.2 | 442.2 | 96.50 ms ± 3.58% | 97.23 ms ± 3.01% | 92.88 ms ± 3.01% |
| Angular 1.2.5 | 701.7 | 72.55 ms ± 3.21% | 77.85 ms ± 1.96% | 75.76 ms ± 3.39% |
| Total | 1994.3 | 310.07 | 309.74 | 303.38 |

Change:
 +9.22%
