### PR TITLE
Issue 522: Linear comment attachment algorithm

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -364,15 +364,9 @@ parseStatement: true, parseSourceElement: true */
             comment.loc = loc;
         }
         extra.comments.push(comment);
-
         if (extra.attachComment) {
-            attacher = {
-                comment: comment,
-                leading: null,
-                trailing: null,
-                range: [start, end]
-            };
-            extra.pendingComments.push(attacher);
+            extra.leadingComments.push(comment);
+            extra.trailingComments.push(comment);
         }
     }
 
@@ -1508,43 +1502,55 @@ parseStatement: true, parseSourceElement: true */
         name: 'SyntaxTree',
 
         processComment: function (node) {
-            var i, attacher, pos, len, candidate;
-
+            var lastChild, trailingComments;
             if (typeof node.type === 'undefined' || node.type === Syntax.Program) {
                 return;
             }
 
-            // Check for possible additional trailing comments.
+            // FIXME(ikarienator): We are somehow calling processComment multiple times on the same node.
+            if (extra.bottomRightStack.length > 0 && extra.bottomRightStack[extra.bottomRightStack.length - 1] === node) {
+                return;
+            }
+
             peek();
 
-            for (i = 0; i < extra.pendingComments.length; ++i) {
-                attacher = extra.pendingComments[i];
-                if (node.range[0] >= attacher.comment.range[1]) {
-                    candidate = attacher.leading;
-                    if (candidate) {
-                        pos = candidate.range[0];
-                        len = candidate.range[1] - pos;
-                        if (node.range[0] <= pos && (node.range[1] - node.range[0] >= len)) {
-                            attacher.leading = node;
-                        }
-                    } else {
-                        attacher.leading = node;
-                    }
+            if (extra.trailingComments.length > 0) {
+                if (extra.trailingComments[0].range[0] >= node.range[1]) {
+                    trailingComments = extra.trailingComments;
+                    extra.trailingComments = [];
+                } else {
+                    extra.trailingComments.length = 0;
                 }
-                if (node.range[1] <= attacher.comment.range[0]) {
-                    candidate = attacher.trailing;
-                    if (candidate) {
-                        pos = candidate.range[0];
-                        len = candidate.range[1] - pos;
-                        /* istanbul ignore else */
-                        if (node.range[0] <= pos && (node.range[1] - node.range[0] >= len)) {
-                            attacher.trailing = node;
-                        }
-                    } else {
-                        attacher.trailing = node;
-                    }
+            } else {
+                if (extra.bottomRightStack.length > 0 &&
+                        extra.bottomRightStack[extra.bottomRightStack.length - 1].trailingComments &&
+                        extra.bottomRightStack[extra.bottomRightStack.length - 1].trailingComments[0].range[0] >= node.range[1]) {
+                    trailingComments = extra.bottomRightStack[extra.bottomRightStack.length - 1].trailingComments;
+                    delete extra.bottomRightStack[extra.bottomRightStack.length - 1].trailingComments;
                 }
             }
+
+            // Eating the stack.
+            while (extra.bottomRightStack.length > 0 && extra.bottomRightStack[extra.bottomRightStack.length - 1].range[0] >= node.range[0]) {
+                lastChild = extra.bottomRightStack.pop();
+            }
+
+            if (lastChild) {
+                if (lastChild.leadingComments && lastChild.leadingComments[lastChild.leadingComments.length - 1].range[1] <= node.range[0]) {
+                    node.leadingComments = lastChild.leadingComments;
+                    delete lastChild.leadingComments;
+                }
+            } else if (extra.leadingComments.length > 0 && extra.leadingComments[extra.leadingComments.length - 1].range[1] <= node.range[0]) {
+                node.leadingComments = extra.leadingComments;
+                extra.leadingComments = [];
+            }
+
+
+            if (trailingComments) {
+                node.trailingComments = trailingComments;
+            }
+
+            extra.bottomRightStack.push(node);
         },
 
         markEnd: function (node, startToken) {
@@ -3777,31 +3783,6 @@ parseStatement: true, parseSourceElement: true */
         return delegate.markEnd(delegate.createProgram(body), startToken);
     }
 
-    function attachComments() {
-        var i, attacher, comment, leading, trailing;
-
-        for (i = 0; i < extra.pendingComments.length; ++i) {
-            attacher = extra.pendingComments[i];
-            comment = attacher.comment;
-            leading = attacher.leading;
-            if (leading) {
-                if (typeof leading.leadingComments === 'undefined') {
-                    leading.leadingComments = [];
-                }
-                leading.leadingComments.push(attacher.comment);
-            }
-            trailing = attacher.trailing;
-            if (trailing) {
-                /* istanbul ignore else */
-                if (typeof trailing.trailingComments === 'undefined') {
-                    trailing.trailingComments = [];
-                }
-                trailing.trailingComments.push(attacher.comment);
-            }
-        }
-        extra.pendingComments = [];
-    }
-
     function filterTokenLocation() {
         var i, entry, token, tokens = [];
 
@@ -3957,8 +3938,10 @@ parseStatement: true, parseSourceElement: true */
             }
             if (extra.attachComment) {
                 extra.range = true;
-                extra.pendingComments = [];
                 extra.comments = [];
+                extra.bottomRightStack = [];
+                extra.trailingComments = [];
+                extra.leadingComments = [];
             }
         }
 
@@ -3973,9 +3956,6 @@ parseStatement: true, parseSourceElement: true */
             }
             if (typeof extra.errors !== 'undefined') {
                 program.errors = extra.errors;
-            }
-            if (extra.attachComment) {
-                attachComments();
             }
         } catch (e) {
             throw e;

--- a/test/test.js
+++ b/test/test.js
@@ -3364,6 +3364,68 @@ var testFixture = {
             }
         },
 
+        '42 /* block comment 1 */ /* block comment 2 */': {
+            "type": "Program",
+            "body": [
+                {
+                    "type": "ExpressionStatement",
+                    "expression": {
+                        "type": "Literal",
+                        "value": 42,
+                        "raw": "42",
+                        "range": [
+                            0,
+                            2
+                        ],
+                        "trailingComments": [
+                            {
+                                "type": "Block",
+                                "value": " block comment 1 ",
+                                "range": [
+                                    3,
+                                    24
+                                ]
+                            },
+                            {
+                                "type": "Block",
+                                "value": " block comment 2 ",
+                                "range": [
+                                    25,
+                                    46
+                                ]
+                            }
+                        ]
+                    },
+                    "range": [
+                        0,
+                        46
+                    ]
+                }
+            ],
+            "range": [
+                0,
+                46
+            ],
+            "comments": [
+                {
+                    "type": "Block",
+                    "value": " block comment 1 ",
+                    "range": [
+                        3,
+                        24
+                    ]
+                },
+                {
+                    "type": "Block",
+                    "value": " block comment 2 ",
+                    "range": [
+                        25,
+                        46
+                    ]
+                }
+            ]
+        },
+
         '(a + /* assignmenr */b ) * c': {
             "type": "Program",
             "body": [


### PR DESCRIPTION
[Issue 522: Linear comment attachment algorithm](https://code.google.com/p/esprima/issues/detail?id=522&thanks=522&ts=1396463391)

Linear comment attachment to replace the quadratic comment attachment algorithm.

Before:

| Source | Size(KiB) | Time(ms) |
| :-: | --: | --: |
| Underscore 1.5.2 | 42.50 | 31.30 |
| Backbone 1.1.0 | 58.70 | 60.02 |
| MooTools 1.4.5 | 156.70 | 211.06 |
| jQuery 1.9.1 | 262.10 | 1461.83 |
| YUI 3.12.0 | 330.40 | 759.88 |
| jQuery.Mobile 1.4.2 | 442.20 | 3713.60 |
| Angular 1.2.5 | 701.70 | 1175.43 |
| Total | 1,994.30 | 7,413.12 |

After:

| Source | Size(KiB) | Time(ms) |
| :-: | --: | --: |
| Underscore 1.5.2 | 42.5 | 5.34 |
| Backbone 1.1.0 | 58.7 | 5.81 |
| MooTools 1.4.5 | 156.7 | 25.69 |
| jQuery 1.9.1 | 262.1 | 69.75 |
| YUI 3.12.0 | 330.4 | 50.95 |
| jQuery.Mobile 1.4.2 | 442.2 | 118.27 |
| Angular 1.2.5 | 701.7 | 93.07 |
| Total | 1994.3 | 368.88 |

Speed up: **20.1x**

Note that this is only 1.8x slower than without comment attachment, which is exactly the performance without comment attachment a week ago before the series of optimizations.
