### PR TITLE
disable location tracking to make comparison more fair

### DIFF
--- a/test/compare.js
+++ b/test/compare.js
@@ -251,7 +251,7 @@ if (typeof window !== 'undefined') {
                 switch (parser) {
                 case 'Esprima':
                     fn = function () {
-                        var syntax = window.esprima.parse(source, { range: true, loc: true });
+                        var syntax = window.esprima.parse(source, { range: false, loc: false });
                         window.tree.push(syntax.body.length);
                     };
                     break;
@@ -275,7 +275,7 @@ if (typeof window !== 'undefined') {
 
                 case 'Acorn':
                     fn = function () {
-                        var syntax = window.acorn.parse(source, { ranges: true, locations: true });
+                        var syntax = window.acorn.parse(source, { ranges: false, locations: false });
                         window.tree.push(syntax.body.length);
                     };
                     break;


### PR DESCRIPTION
With location tracking enabled on only the parsers that support it, the results are strongly skewed.

Results with location tracking:

```
Source             Esprima      UglifyJS2     Traceur      Acorn
Underscore 1.5.2    7.8 ±0.5%    13.1 ±7.5%    7.1 ±2.3%    4.5 ±0.9%
Backbone 1.1.0      9.3 ±0.5%    19.5 ±4.4%    8.0 ±2.1%    4.9 ±2.9%
jQuery 1.9.1       51.1 ±4.3%   138.6 ±8.3%   41.9 ±4.7%   28.8 ±7.2%
Total              68.2 ms      171.1 ms      57.0 ms      38.2 ms
```

Results without location tracking:

```
Source             Esprima      UglifyJS2     Traceur      Acorn
Underscore 1.5.2    2.8 ±2.0%    13.6 ±7.5%    6.9 ±1.0%    2.8 ±2.9%
Backbone 1.1.0      2.8 ±0.3%    20.8 ±3.1%    7.7 ±2.1%    3.3 ±1.9%
jQuery 1.9.1       17.4 ±0.2%   138.3 ±7.9%   41.9 ±1.5%   17.0 ±1.3%
Total              23.1 ms      172.8 ms      56.5 ms      23.1 ms
```
