### PR TITLE
Introduce Literal with undefined instead of null for [,,]

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2080,6 +2080,16 @@ parseStatement: true, parseSourceElement: true */
         return expr.type === Syntax.Identifier || expr.type === Syntax.MemberExpression;
     }
 
+    // Empty literal node for array holes
+
+    function parseArrayHole() {
+        var token;
+        token = lex();
+        token.value = undefined;
+        token.start += 1;
+        return delegate.markEnd(delegate.createLiteral(token), token);
+    }
+
     // 11.1.4 Array Initialiser
 
     function parseArrayInitialiser() {
@@ -2090,8 +2100,7 @@ parseStatement: true, parseSourceElement: true */
 
         while (!match(']')) {
             if (match(',')) {
-                lex();
-                elements.push(null);
+                elements.push(parseArrayHole());
             } else {
                 elements.push(parseAssignmentExpression());
 

--- a/test/reflect.js
+++ b/test/reflect.js
@@ -25,6 +25,7 @@ function throwStmt(expr) { return Pattern({ type: "ThrowStatement", argument: ex
 function returnStmt(expr) { return Pattern({ type: "ReturnStatement", argument: expr }) }
 function yieldExpr(expr) { return Pattern({ type: "YieldExpression", argument: expr }) }
 function lit(val) { return Pattern({ type: "Literal", value: val }) }
+var litu = Pattern({ type: "Literal", value: undefined });
 var thisExpr = Pattern({ type: "ThisExpression" });
 function funDecl(id, params, body) { return Pattern({ type: "FunctionDeclaration",
                                              id: id,
@@ -287,17 +288,17 @@ assertExpr("[]", arrExpr([]));
 assertExpr("[1]", arrExpr([lit(1)]));
 assertExpr("[1,2]", arrExpr([lit(1),lit(2)]));
 assertExpr("[1,2,3]", arrExpr([lit(1),lit(2),lit(3)]));
-assertExpr("[1,,2,3]", arrExpr([lit(1),,lit(2),lit(3)]));
-assertExpr("[1,,,2,3]", arrExpr([lit(1),,,lit(2),lit(3)]));
-assertExpr("[1,,,2,,3]", arrExpr([lit(1),,,lit(2),,lit(3)]));
-assertExpr("[1,,,2,,,3]", arrExpr([lit(1),,,lit(2),,,lit(3)]));
-assertExpr("[,1,2,3]", arrExpr([,lit(1),lit(2),lit(3)]));
-assertExpr("[,,1,2,3]", arrExpr([,,lit(1),lit(2),lit(3)]));
-assertExpr("[,,,1,2,3]", arrExpr([,,,lit(1),lit(2),lit(3)]));
-assertExpr("[,,,1,2,3,]", arrExpr([,,,lit(1),lit(2),lit(3)]));
-assertExpr("[,,,1,2,3,,]", arrExpr([,,,lit(1),lit(2),lit(3),undefined]));
-assertExpr("[,,,1,2,3,,,]", arrExpr([,,,lit(1),lit(2),lit(3),undefined,undefined]));
-assertExpr("[,,,,,]", arrExpr([undefined,undefined,undefined,undefined,undefined]));
+assertExpr("[1,,2,3]", arrExpr([lit(1),litu,lit(2),lit(3)]));
+assertExpr("[1,,,2,3]", arrExpr([lit(1),litu,litu,lit(2),lit(3)]));
+assertExpr("[1,,,2,,3]", arrExpr([lit(1),litu,litu,lit(2),litu,lit(3)]));
+assertExpr("[1,,,2,,,3]", arrExpr([lit(1),litu,litu,lit(2),litu,litu,lit(3)]));
+assertExpr("[,1,2,3]", arrExpr([litu,lit(1),lit(2),lit(3)]));
+assertExpr("[,,1,2,3]", arrExpr([litu,litu,lit(1),lit(2),lit(3)]));
+assertExpr("[,,,1,2,3]", arrExpr([litu,litu,litu,lit(1),lit(2),lit(3)]));
+assertExpr("[,,,1,2,3,]", arrExpr([litu,litu,litu,lit(1),lit(2),lit(3)]));
+assertExpr("[,,,1,2,3,,]", arrExpr([litu,litu,litu,lit(1),lit(2),lit(3),litu]));
+assertExpr("[,,,1,2,3,,,]", arrExpr([litu,litu,litu,lit(1),lit(2),lit(3),litu,litu]));
+assertExpr("[,,,,,]", arrExpr([litu,litu,litu,litu,litu]));
 assertExpr("({})", objExpr([]));
 assertExpr("({x:1})", objExpr([objProp(ident("x"), lit(1), "init")]));
 assertExpr("({x:1, y:2})", objExpr([objProp(ident("x"), lit(1), "init"),

--- a/test/test.js
+++ b/test/test.js
@@ -537,19 +537,34 @@ var testFixture = {
                 },
                 right: {
                     type: 'ArrayExpression',
-                    elements: [
-                        null,
-                        null,
-                        {
-                            type: 'Literal',
-                            value: 42,
-                            raw: '42',
-                            range: [9, 11],
-                            loc: {
-                                start: { line: 1, column: 9 },
-                                end: { line: 1, column: 11 }
-                            }
-                        }],
+                    elements: [{
+                        type: 'Literal',
+                        value: undefined,
+                        raw: '',
+                        range: [7, 7],
+                        loc: {
+                            start: { line: 1, column: 7 },
+                            end: { line: 1, column: 7 }
+                        }
+                    }, {
+                        type: 'Literal',
+                        value: undefined,
+                        raw: '',
+                        range: [8, 8],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 8 }
+                        }
+                    }, {
+                        type: 'Literal',
+                        value: 42,
+                        raw: '42',
+                        range: [9, 11],
+                        loc: {
+                            start: { line: 1, column: 9 },
+                            end: { line: 1, column: 11 }
+                        }
+                    }],
                     range: [4, 13],
                     loc: {
                         start: { line: 1, column: 4 },
@@ -666,7 +681,16 @@ var testFixture = {
                             start: { line: 1, column: 9 },
                             end: { line: 1, column: 10 }
                         }
-                    }, null, {
+                    }, {
+                        type: 'Literal',
+                        value: undefined,
+                        raw: '',
+                        range: [12, 12],
+                        loc: {
+                            start: { line: 1, column: 12 },
+                            end: { line: 1, column: 12 }
+                        }
+                    }, {
                         type: 'Literal',
                         value: 3,
                         raw: '3',


### PR DESCRIPTION
[Issue 525](https://code.google.com/p/esprima/issues/detail?id=525)

required for mdevils/node-jscs/issues/315
null don't have any information about where the token was.
for example:

``` js
var x = [
  , 4,
  ,
];
```

WARN: I'm not sure about `lookahead`, is it right to use it in parseEmptyExpression?
