### PR TITLE
Exclude tests from published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,5 @@
 /assets/
 /coverage/
 /demo/
-/test/3rdparty
+/test/
 /tools/


### PR DESCRIPTION
Related to facebook/esprima#16 and substack/node-browserify#707 .

Removing the tests from the package significantly decreases download size.  This is magnified when large projects like browserify ultimately include many versions of esprima.

This could also be merged into master.
