### PR TITLE
Support for object computed property keys syntax

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1779,14 +1779,15 @@ parseYieldExpression: true
             };
         },
 
-        createProperty: function (kind, key, value, method, shorthand) {
+        createProperty: function (kind, key, value, method, shorthand, computedKey) {
             return {
                 type: Syntax.Property,
                 key: key,
                 value: value,
                 kind: kind,
                 method: method,
-                shorthand: shorthand
+                shorthand: shorthand,
+                computedKey: computedKey
             };
         },
 
@@ -2376,6 +2377,15 @@ parseYieldExpression: true
 
         token = lookahead;
 
+        if (match('[')) {
+            expect('[');
+            key = parseExpression();
+            expect(']');
+            expect(':');
+
+            return markerApply(marker, delegate.createProperty('init', key, parseAssignmentExpression(), false, false, true));
+        }
+
         if (token.type === Token.Identifier) {
 
             id = parseObjectPropertyKey();
@@ -2386,7 +2396,7 @@ parseYieldExpression: true
                 key = parseObjectPropertyKey();
                 expect('(');
                 expect(')');
-                return markerApply(marker, delegate.createProperty('get', key, parsePropertyFunction({ generator: false }), false, false));
+                return markerApply(marker, delegate.createProperty('get', key, parsePropertyFunction({ generator: false }), false, false, false));
             }
             if (token.value === 'set' && !(match(':') || match('('))) {
                 key = parseObjectPropertyKey();
@@ -2394,16 +2404,16 @@ parseYieldExpression: true
                 token = lookahead;
                 param = [ parseVariableIdentifier() ];
                 expect(')');
-                return markerApply(marker, delegate.createProperty('set', key, parsePropertyFunction({ params: param, generator: false, name: token }), false, false));
+                return markerApply(marker, delegate.createProperty('set', key, parsePropertyFunction({ params: param, generator: false, name: token }), false, false, false));
             }
             if (match(':')) {
                 lex();
-                return markerApply(marker, delegate.createProperty('init', id, parseAssignmentExpression(), false, false));
+                return markerApply(marker, delegate.createProperty('init', id, parseAssignmentExpression(), false, false, false));
             }
             if (match('(')) {
-                return markerApply(marker, delegate.createProperty('init', id, parsePropertyMethodFunction({ generator: false }), true, false));
+                return markerApply(marker, delegate.createProperty('init', id, parsePropertyMethodFunction({ generator: false }), true, false, false));
             }
-            return markerApply(marker, delegate.createProperty('init', id, id, false, true));
+            return markerApply(marker, delegate.createProperty('init', id, id, false, true, false));
         }
         if (token.type === Token.EOF || token.type === Token.Punctuator) {
             if (!match('*')) {
@@ -2417,15 +2427,15 @@ parseYieldExpression: true
                 throwUnexpected(lex());
             }
 
-            return markerApply(marker, delegate.createProperty('init', id, parsePropertyMethodFunction({ generator: true }), true, false));
+            return markerApply(marker, delegate.createProperty('init', id, parsePropertyMethodFunction({ generator: true }), true, false, false));
         }
         key = parseObjectPropertyKey();
         if (match(':')) {
             lex();
-            return markerApply(marker, delegate.createProperty('init', key, parseAssignmentExpression(), false, false));
+            return markerApply(marker, delegate.createProperty('init', key, parseAssignmentExpression(), false, false, false));
         }
         if (match('(')) {
-            return markerApply(marker, delegate.createProperty('init', key, parsePropertyMethodFunction({ generator: false }), true, false));
+            return markerApply(marker, delegate.createProperty('init', key, parsePropertyMethodFunction({ generator: false }), true, false, false));
         }
         throwUnexpected(lex());
     }

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -1143,6 +1143,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [8, 20],
                         loc: {
                             start: { line: 1, column: 8 },
@@ -2159,6 +2160,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 18],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2245,6 +2247,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 22],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2324,6 +2327,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 20],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2402,6 +2406,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 15],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2480,6 +2485,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 15],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2559,6 +2565,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 17],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2638,6 +2645,7 @@ var harmonyTestFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 21],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2742,6 +2750,7 @@ var harmonyTestFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 29],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3292,6 +3301,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [6, 7],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3320,6 +3330,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [9, 10],
                         loc: {
                             start: { line: 1, column: 9 },
@@ -3449,6 +3460,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [3, 21],
                         loc: {
                             start: { line: 1, column: 3 },
@@ -3512,6 +3524,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [7, 8],
                         loc: {
                             start: { line: 1, column: 7 },
@@ -3620,6 +3633,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [5, 6],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -3728,6 +3742,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [5, 6],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -3836,6 +3851,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [7, 10],
                         loc: {
                             start: { line: 1, column: 7 },
@@ -3900,6 +3916,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [5, 8],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -3964,6 +3981,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [5, 8],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -6120,6 +6138,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [10, 31],
                         loc: {
                             start: { line: 1, column: 10 },
@@ -8960,6 +8979,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 25],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -9055,6 +9075,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: true,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 15],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -9228,6 +9249,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: true,
+                    computedKey: false,
                     range: [13, 14],
                     loc: {
                         start: { line: 1, column: 13 },
@@ -9256,6 +9278,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: true,
+                    computedKey: false,
                     range: [16, 17],
                     loc: {
                         start: { line: 1, column: 16 },
@@ -9333,6 +9356,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: true,
+                    computedKey: false,
                     range: [16, 17],
                     loc: {
                         start: { line: 1, column: 16 },
@@ -9470,6 +9494,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [18, 19],
                             loc: {
                                 start: { line: 1, column: 18 },
@@ -9498,6 +9523,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [21, 22],
                             loc: {
                                 start: { line: 1, column: 21 },
@@ -9513,6 +9539,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: false,
+                    computedKey: false,
                     range: [13, 24],
                     loc: {
                         start: { line: 1, column: 13 },
@@ -9557,6 +9584,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: false,
+                    computedKey: false,
                     range: [26, 35],
                     loc: {
                         start: { line: 1, column: 26 },
@@ -9723,6 +9751,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [14, 15],
                         loc: {
                             start: { line: 1, column: 14 },
@@ -9751,6 +9780,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [17, 18],
                         loc: {
                             start: { line: 1, column: 17 },
@@ -9904,6 +9934,7 @@ var harmonyTestFixture = {
                                 kind: 'init',
                                 method: false,
                                 shorthand: true,
+                                computedKey: false,
                                 range: [19, 20],
                                 loc: {
                                     start: { line: 1, column: 19 },
@@ -9932,6 +9963,7 @@ var harmonyTestFixture = {
                                 kind: 'init',
                                 method: false,
                                 shorthand: true,
+                                computedKey: false,
                                 range: [22, 23],
                                 loc: {
                                     start: { line: 1, column: 22 },
@@ -9947,6 +9979,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [14, 25],
                         loc: {
                             start: { line: 1, column: 14 },
@@ -9991,6 +10024,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [27, 36],
                         loc: {
                             start: { line: 1, column: 27 },
@@ -10126,6 +10160,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: true,
                     shorthand: false,
+                    computedKey: false,
                     range: [3, 16],
                     loc: {
                         start: { line: 1, column: 3 },
@@ -10210,6 +10245,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: true,
                     shorthand: false,
+                    computedKey: false,
                     range: [3, 19],
                     loc: {
                         start: { line: 1, column: 3 },
@@ -10285,6 +10321,7 @@ var harmonyTestFixture = {
                                         kind: 'init',
                                         method: false,
                                         shorthand: true,
+                                        computedKey: false,
                                         range: [12, 13],
                                         loc: {
                                             start: { line: 1, column: 12 },
@@ -10313,6 +10350,7 @@ var harmonyTestFixture = {
                                         kind: 'init',
                                         method: false,
                                         shorthand: true,
+                                        computedKey: false,
                                         range: [15, 16],
                                         loc: {
                                             start: { line: 1, column: 15 },
@@ -10328,6 +10366,7 @@ var harmonyTestFixture = {
                                 kind: 'init',
                                 method: false,
                                 shorthand: false,
+                                computedKey: false,
                                 range: [7, 18],
                                 loc: {
                                     start: { line: 1, column: 7 },
@@ -10372,6 +10411,7 @@ var harmonyTestFixture = {
                                 kind: 'init',
                                 method: false,
                                 shorthand: false,
+                                computedKey: false,
                                 range: [20, 29],
                                 loc: {
                                     start: { line: 1, column: 20 },
@@ -10438,6 +10478,7 @@ var harmonyTestFixture = {
                     kind: 'init',
                     method: true,
                     shorthand: false,
+                    computedKey: false,
                     range: [3, 48],
                     loc: {
                         start: { line: 1, column: 3 },
@@ -10574,6 +10615,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [3, 4],
                         loc: {
                             start: { line: 1, column: 3 },
@@ -10642,6 +10684,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [3, 4],
                         loc: {
                             start: { line: 1, column: 3 },
@@ -10843,6 +10886,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [3, 12],
                         loc: {
                             start: { line: 1, column: 3 },
@@ -10918,6 +10962,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [3, 7],
                         loc: {
                             start: { line: 1, column: 3 },
@@ -10946,6 +10991,7 @@ var harmonyTestFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: true,
+                        computedKey: false,
                         range: [9, 10],
                         loc: {
                             start: { line: 1, column: 9 },
@@ -11163,6 +11209,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [3, 4],
                             loc: {
                                 start: { line: 1, column: 3 },
@@ -11191,6 +11238,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [6, 7],
                             loc: {
                                 start: { line: 1, column: 6 },
@@ -11466,6 +11514,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [7, 8],
                             loc: {
                                 start: { line: 1, column: 7 },
@@ -11494,6 +11543,7 @@ var harmonyTestFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: true,
+                            computedKey: false,
                             range: [10, 11],
                             loc: {
                                 start: { line: 1, column: 10 },
@@ -11722,6 +11772,181 @@ var harmonyTestFixture = {
         }
     },
 
+
+    'ES6: Computed Property Name': {
+        'a = { [b]: 1 }': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'a',
+                    range: [ 0, 1 ],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 1 }
+                    }
+                },
+                right: {
+                    type: 'ObjectExpression',
+                    properties: [
+                        {
+                            type: 'Property',
+                            key: {
+                                type: 'Identifier',
+                                name: 'b',
+                                range: [ 7, 8 ],
+                                loc: {
+                                    start: { line: 1, column: 7 },
+                                    end: { line: 1, column: 8 }
+                                }
+                            },
+                            value: {
+                                type: 'Literal',
+                                value: 1,
+                                raw: '1',
+                                range: [ 11, 12 ],
+                                loc: {
+                                    start: { line: 1, column: 11 },
+                                    end: { line: 1, column: 12 }
+                                }
+                            },
+                            kind: 'init',
+                            method: false,
+                            shorthand: false,
+                            computedKey: true,
+                            range: [ 6, 12 ],
+                            loc: {
+                                start: { line: 1, column: 6 },
+                                end: { line: 1, column: 12 }
+                            }
+                        }
+                    ],
+                    range: [ 4, 14 ],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 14 }
+                    }
+                },
+                range: [ 0, 14 ],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 14 }
+                }
+            },
+            range: [ 0, 14 ],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 14 }
+            }
+        },
+        'a = { [b++ + ++c]: 1 }': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'a',
+                    range: [ 0, 1 ],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 1 }
+                    }
+                },
+                right: {
+                    type: 'ObjectExpression',
+                    properties: [
+                        {
+                            type: 'Property',
+                            key: {
+                                type: 'BinaryExpression',
+                                operator: '+',
+                                left: {
+                                    type: 'UpdateExpression',
+                                    operator: '++',
+                                    argument: {
+                                        type: 'Identifier',
+                                        name: 'b',
+                                        range: [ 7, 8 ],
+                                        loc: {
+                                            start: { line: 1, column: 7 },
+                                            end: { line: 1, column: 8 }
+                                        }
+                                    },
+                                    prefix: false,
+                                    range: [ 7, 10 ],
+                                    loc: {
+                                        start: { line: 1, column: 7 },
+                                        end: { line: 1, column: 10 }
+                                    }
+                                },
+                                right: {
+                                    type: 'UpdateExpression',
+                                    operator: '++',
+                                    argument: {
+                                        type: 'Identifier',
+                                        name: 'c',
+                                        range: [ 15, 16 ],
+                                        loc: {
+                                            start: { line: 1, column: 15 },
+                                            end: { line: 1, column: 16 }
+                                        }
+                                    },
+                                    prefix: true,
+                                    range: [ 13, 16 ],
+                                    loc: {
+                                        start: { line: 1, column: 13 },
+                                        end: { line: 1, column: 16 }
+                                    }
+                                },
+                                range: [ 7, 16 ],
+                                loc: {
+                                    start: { line: 1, column: 7 },
+                                    end: { line: 1, column: 16 }
+                                }
+                            },
+                            value: {
+                                type: 'Literal',
+                                value: 1,
+                                raw: '1',
+                                range: [ 19, 20 ],
+                                loc: {
+                                    start: { line: 1, column: 19 },
+                                    end: { line: 1, column: 20 }
+                                }
+                            },
+                            kind: 'init',
+                            method: false,
+                            shorthand: false,
+                            computedKey: true,
+                            range: [ 6, 20 ],
+                            loc: {
+                                start: { line: 1, column: 6 },
+                                end: { line: 1, column: 20 }
+                            }
+                        }
+                    ],
+                    range: [ 4, 22 ],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 22 }
+                    }
+                },
+                range: [ 0, 22 ],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 22 }
+                }
+            },
+            range: [ 0, 22 ],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 22 }
+            }
+        }
+    },
 
     'Harmony Invalid syntax': {
 

--- a/test/reflect.js
+++ b/test/reflect.js
@@ -99,7 +99,7 @@ function newExpr(callee, args) { return Pattern({ type: "NewExpression", callee:
 function callExpr(callee, args) { return Pattern({ type: "CallExpression", callee: callee, arguments: args }) }
 function arrExpr(elts) { return Pattern({ type: "ArrayExpression", elements: elts }) }
 function objExpr(elts) { return Pattern({ type: "ObjectExpression", properties: elts }) }
-function objProp(key, value, kind) { return Pattern({ type: "Property", key: key, value: value, kind: kind, method: false, shorthand: false }) }
+function objProp(key, value, kind) { return Pattern({ type: "Property", key: key, value: value, kind: kind, method: false, shorthand: false, computedKey: false }) }
 
 function arrPatt(elts) { return Pattern({ type: "ArrayPattern", elements: elts }) }
 function objPatt(elts) { return Pattern({ type: "ObjectPattern", properties: elts }) }

--- a/test/test.js
+++ b/test/test.js
@@ -1151,6 +1151,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 16],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1216,6 +1217,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 12],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1281,6 +1283,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 14],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1346,6 +1349,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 15],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1411,6 +1415,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 14],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1477,6 +1482,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 18],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1543,6 +1549,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [6, 10],
                             loc: {
                                 start: { line: 1, column: 6 },
@@ -1573,6 +1580,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [12, 16],
                             loc: {
                                 start: { line: 1, column: 12 },
@@ -1668,6 +1676,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 36],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1746,6 +1755,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 20],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1824,6 +1834,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 17],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1902,6 +1913,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 19],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -1980,6 +1992,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 20],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2058,6 +2071,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 19],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2137,6 +2151,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 22],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2216,6 +2231,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 17],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2336,6 +2352,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 34],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2456,6 +2473,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 28],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2576,6 +2594,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 32],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2696,6 +2715,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 34],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2816,6 +2836,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 32],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -2937,6 +2958,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 34],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3058,6 +3080,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 30],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3123,6 +3146,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 13],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3188,6 +3212,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 13],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3253,6 +3278,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 18],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3319,6 +3345,7 @@ var testFixture = {
                         kind: 'init',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [5, 19],
                         loc: {
                             start: { line: 1, column: 5 },
@@ -3413,6 +3440,7 @@ var testFixture = {
                         kind: 'get',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [6, 36],
                         loc: {
                             start: { line: 1, column: 6 },
@@ -3497,6 +3525,7 @@ var testFixture = {
                         kind: 'set',
                         method: false,
                         shorthand: false,
+                        computedKey: false,
                         range: [38, 75],
                         loc: {
                             start: { line: 1, column: 38 },
@@ -14185,6 +14214,7 @@ var testFixture = {
                     kind: 'init',
                     method: false,
                     shorthand: false,
+                    computedKey: false,
                     range: [8, 24],
                     loc: {
                         start: { line: 1, column: 8 },
@@ -20615,6 +20645,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [16, 19],
                             loc: {
                                 start: { line: 1, column: 16 },
@@ -20644,6 +20675,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [20, 23],
                             loc: {
                                 start: { line: 1, column: 20 },
@@ -21672,6 +21704,7 @@ var testFixture = {
                             kind: 'set',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [20, 34],
                             loc: {
                                 start: { line: 1, column: 20 },
@@ -21898,6 +21931,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [24, 30],
                             loc: {
                                 start: { line: 1, column: 24 },
@@ -22007,6 +22041,7 @@ var testFixture = {
                             kind: 'get',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [24, 34],
                             loc: {
                                 start: { line: 1, column: 24 },
@@ -22049,6 +22084,7 @@ var testFixture = {
                             kind: 'get',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [36, 46],
                             loc: {
                                 start: { line: 1, column: 36 },
@@ -22145,6 +22181,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [24, 29],
                             loc: {
                                 start: { line: 1, column: 24 },
@@ -22187,6 +22224,7 @@ var testFixture = {
                             kind: 'get',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [31, 41],
                             loc: {
                                 start: { line: 1, column: 31 },
@@ -22304,6 +22342,7 @@ var testFixture = {
                             kind: 'set',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [24, 35],
                             loc: {
                                 start: { line: 1, column: 24 },
@@ -22333,6 +22372,7 @@ var testFixture = {
                             kind: 'init',
                             method: false,
                             shorthand: false,
+                            computedKey: false,
                             range: [37, 42],
                             loc: {
                                 start: { line: 1, column: 37 },


### PR DESCRIPTION
Hello!

I want to support for object computed property keys syntax in esprima parser.
But I'm not sure about right way to do it.
I need your help to make that PR done.
