### PR TITLE
Issue 549: A missing comma in a argument list should not prevent parsing when tolerant:true

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1981,6 +1981,26 @@ parseStatement: true, parseSourceElement: true */
         }
     }
 
+    /**
+     * @name expectTolerant
+     * @description Quietly expect the given token value when in tolerant mode, otherwise delegates
+     * to <code>expect(value)</code>
+     * @param {String} value The value we are expecting the lookahead token to have
+     * @since 2.0
+     */
+    function expectTolerant(value) {
+        if (extra.errors) {
+            var token = lookahead;
+            if (token.type !== Token.Punctuator && token.value !== value) {
+                throwErrorTolerant(token, Messages.UnexpectedToken, token.value);
+            } else {
+                lex();
+            }
+        } else {
+            expect(value);
+        }
+    }
+
     // Expect the next token to match the specified keyword.
     // If not, an exception will be thrown.
 
@@ -2194,16 +2214,7 @@ parseStatement: true, parseSourceElement: true */
             properties.push(property);
 
             if (!match('}')) {
-                if (extra.errors) {
-                    token = lookahead;
-                    if (token.type !== Token.Punctuator && token.value !== ',') {
-                        throwErrorTolerant(token, Messages.UnexpectedToken, token.value);
-                    } else {
-                        lex();
-                    }
-                } else {
-                    expect(',');
-                }
+                expectTolerant(',');
             }
         }
 
@@ -2306,7 +2317,7 @@ parseStatement: true, parseSourceElement: true */
                 if (match(')')) {
                     break;
                 }
-                expect(',');
+                expectTolerant(',');
             }
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -23690,6 +23690,232 @@ var testFixture = {
     },
 
     'Tolerant parse': {
+        /** argument recovery */
+        'f(a b c);': {
+            range: [0, 9],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 9 }
+            },
+            type: "Program",
+            body: [{
+                range: [0, 9],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 9 }
+                },
+                type: "ExpressionStatement",
+                expression: {
+                    range: [0, 8],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 8 }
+                    },
+                    type: "CallExpression",
+                    callee: {
+                        range: [0, 1],
+                        loc: {
+                            start: { line: 1, column: 0 },
+                            end: { line: 1, column: 1 }
+                        },
+                        type: "Identifier",
+                        name: "f"
+                    },
+                    "arguments": [{
+                        range: [2, 3],
+                        loc: {
+                            start: { line: 1, column: 2 },
+                            end: { line: 1, column: 3 }
+                        },
+                        type: "Identifier",
+                        name: "a"
+                    }, {
+                        range: [4, 5],
+                        loc: {
+                            start: { line: 1, column: 4 },
+                            end: { line: 1, column: 5 }
+                        },
+                        type: "Identifier",
+                        name: "b"
+                    }, {
+                        range: [6, 7],
+                        loc: {
+                            start: { line: 1, column: 6 },
+                            end: { line: 1, column: 7 }
+                        },
+                        type: "Identifier",
+                        name: "c"
+                    }]
+                }
+            }],
+            errors: [{
+                index: 4,
+                lineNumber: 1,
+                column: 5,
+                message: "Error: Line 1: Unexpected token b"
+            }, {
+                index: 6,
+                lineNumber: 1,
+                column: 7,
+                message: "Error: Line 1: Unexpected token c"
+            }]
+        },
+        
+        /** argument recovery function */
+        'f(a function(){} c);': {
+            range: [0, 20],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 20 }
+            },
+            type: "Program",
+            body: [{
+                range: [0, 20],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 20 }
+                },
+                type: "ExpressionStatement",
+                expression: {
+                    range: [0, 19],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 19 }
+                    },
+                    type: "CallExpression",
+                    callee: {
+                        range: [0, 1],
+                        loc: {
+                            start: { line: 1, column: 0 },
+                            end: { line: 1, column: 1 }
+                        },
+                        type: "Identifier",
+                        name: "f"
+                    },
+                    "arguments": [{
+                        range: [2, 3],
+                        loc: {
+                            start: { line: 1, column: 2 },
+                            end: { line: 1, column: 3 }
+                        },
+                        type: "Identifier",
+                        name: "a"
+                    }, {
+                        range: [4, 16],
+                        loc: {
+                            start: { line: 1, column: 4 },
+                            end: { line: 1, column: 16 }
+                        },
+                        type: "FunctionExpression",
+                        id: null,
+                        params: [],
+                        defaults: [],
+                        body: {
+                            range: [14, 16],
+                            loc: {
+                                start: { line: 1, column: 14 },
+                                end: { line: 1, column: 16 }
+                            },
+                            type: "BlockStatement",
+                            body: []
+                        },
+                        rest: null,
+                        generator: false,
+                        expression: false
+                    }, {
+                        range: [17, 18],
+                        loc: {
+                            start: { line: 1, column: 17 },
+                            end: { line: 1, column: 18 }
+                        },
+                        type: "Identifier",
+                        name: "c"
+                    }]
+                }
+            }],
+            errors: [{
+                index: 4,
+                lineNumber: 1,
+                column: 5,
+                message: "Error: Line 1: Unexpected token function"
+            }, {
+                index: 17,
+                lineNumber: 1,
+                column: 18,
+                message: "Error: Line 1: Unexpected token c"
+            }]
+        },
+        
+        /** argument recovery object */
+        'f({} b c);': {
+            range: [0, 10],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 10 }
+            },
+            type: "Program",
+            body: [{
+                range: [0, 10],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 10 }
+                },
+                type: "ExpressionStatement",
+                expression: {
+                    range: [0, 9],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 9 }
+                    },
+                    type: "CallExpression",
+                    callee: {
+                        range: [0, 1],
+                        loc: {
+                            start: { line: 1, column: 0 },
+                            end: { line: 1, column: 1 }
+                        },
+                        type: "Identifier",
+                        name: "f"
+                    },
+                    "arguments": [{
+                        range: [2, 4],
+                        loc: {
+                            start: { line: 1, column: 2 },
+                            end: { line: 1, column: 4 }
+                        },
+                        type: "ObjectExpression",
+                        properties: []
+                    }, {
+                        range: [5, 6],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 6 }
+                        },
+                        type: "Identifier",
+                        name: "b"
+                    }, {
+                        range: [7, 8],
+                        loc: {
+                            start: { line: 1, column: 7 },
+                            end: { line: 1, column: 8 }
+                        },
+                        type: "Identifier",
+                        name: "c"
+                    }]
+                }
+            }],
+            errors: [{
+                index: 5,
+                lineNumber: 1,
+                column: 6,
+                message: "Error: Line 1: Unexpected token b"
+            }, {
+                index: 7,
+                lineNumber: 1,
+                column: 8,
+                message: "Error: Line 1: Unexpected token c"
+            }]
+        },
         
         /** single recovery - missing comma*/
         'var o = {one: function() {} two:2};': {


### PR DESCRIPTION
Issue 549: A missing comma in a argument list should not prevent parsing when tolerant:true

https://code.google.com/p/esprima/issues/detail?id=549
