### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the help of [many contributors](https://github.com/ariya/esprima/contributo
 [Parser AST](https://developer.mozilla.org/en/SpiderMonkey/Parser_API)
 - Optional tracking of syntax node location (index-based and line-column)
 - Heavily tested (> 700 [unit tests](http://esprima.org/test/) with [full code coverage](http://esprima.org/test/coverage.html))
-- [Partial support](http://esprima.org/doc/es6.html) support for ECMAScript 6
+- [Partial support](http://esprima.org/doc/es6.html) for ECMAScript 6
 
 Esprima serves as a **building block** for some JavaScript
 language tools, from [code instrumentation](http://esprima.org/demo/functiontrace.html)


### PR DESCRIPTION
Remove additional word `support` which was repeated twice
