### PR TITLE
No null in ArrowFunctionExpression defaults

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2664,7 +2664,7 @@ parseStatement: true, parseSourceElement: true */
             param = expressions[i];
             if (param.type === Syntax.Identifier) {
                 params.push(param);
-                defaults.push(null);
+                defaults.push(undefined);
                 validateParam(options, param, param.name);
             } else if (param.type === Syntax.AssignmentExpression) {
                 params.push(param.left);


### PR DESCRIPTION
`FunctionExpression` and `FunctionDeclaration` both use `undefined` as a placeholder in their `defaults` list for parameters without a default value. This follows the SpiderMonkey spec which specifies `defaults: [ Expression ];` `ArrowFunctionExpression`, however, is using `null` as a placeholder in its `defaults` list. This is inconsistent and doesn't match the SpiderMonkey spec (though I do understand that matching the SpiderMonkey spec with regards to `ArrowExpression` is a non-goal)
