### PR TITLE
When consumeSemicolon fails to find a semicolon, don't consume anything.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2199,7 +2199,8 @@ parseYieldExpression: true
     }
 
     function consumeSemicolon() {
-        var line;
+        var line, oldIndex = index, oldLineNumber = lineNumber,
+            oldLineStart = lineStart, oldLookahead = lookahead;
 
         // Catch the very common case first: immediately a semicolon (char #59).
         if (source.charCodeAt(index) === 59) {
@@ -2210,6 +2211,10 @@ parseYieldExpression: true
         line = lineNumber;
         skipComment();
         if (lineNumber !== line) {
+            index = oldIndex;
+            lineNumber = oldLineNumber;
+            lineStart = oldLineStart;
+            lookahead = oldLookahead;
             return;
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,16 +44,16 @@ var testFixture = {
                         end: { line: 1, column: 4 }
                     }
                 },
-                range: [0, 5],
+                range: [0, 4],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 4 }
                 }
             }],
-            range: [0, 5],
+            range: [0, 4],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 2, column: 0 }
+                end: { line: 1, column: 4 }
             },
             tokens: [{
                 type: 'Keyword',
@@ -80,16 +80,16 @@ var testFixture = {
                         end: { line: 1, column: 4 }
                     }
                 },
-                range: [0, 5],
+                range: [0, 4],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 4 }
                 }
             }],
-            range: [0, 5],
+            range: [0, 4],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 2, column: 0 }
+                end: { line: 1, column: 4 }
             },
             tokens: [{
                 type: 'Null',
@@ -116,16 +116,16 @@ var testFixture = {
                         end: { line: 2, column: 6 }
                     }
                 },
-                range: [5, 9],
+                range: [5, 7],
                 loc: {
                     start: { line: 2, column: 4 },
-                    end: { line: 4, column: 0 }
+                    end: { line: 2, column: 6 }
                 }
             }],
-            range: [5, 9],
+            range: [5, 7],
             loc: {
                 start: { line: 2, column: 4 },
-                end: { line: 4, column: 0 }
+                end: { line: 2, column: 6 }
             },
             tokens: [{
                 type: 'Numeric',
@@ -15656,10 +15656,10 @@ var testFixture = {
                         end: { line: 1, column: 3 }
                     }
                 },
-                range: [2, 4],
+                range: [2, 3],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 3 }
                 }
             }, {
                 type: 'ExpressionStatement',
@@ -15708,10 +15708,10 @@ var testFixture = {
                         end: { line: 1, column: 3 }
                     }
                 },
-                range: [2, 4],
+                range: [2, 3],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 3 }
                 }
             }, {
                 type: 'ExpressionStatement',
@@ -15833,10 +15833,10 @@ var testFixture = {
                     }
                 }],
                 kind: 'var',
-                range: [2, 20],
+                range: [2, 19],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 19 }
                 }
             }, {
                 type: 'ExpressionStatement',
@@ -16364,10 +16364,10 @@ var testFixture = {
                         end: { line: 1, column: 13 }
                     }
                 },
-                range: [2, 14],
+                range: [2, 13],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 13 }
                 }
             }, {
                 type: 'ExpressionStatement',
@@ -16406,10 +16406,10 @@ var testFixture = {
                         end: { line: 1, column: 13 }
                     }
                 },
-                range: [2, 24],
+                range: [2, 13],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 0 }
+                    end: { line: 1, column: 13 }
                 }
             }, {
                 type: 'ExpressionStatement',
@@ -16448,10 +16448,10 @@ var testFixture = {
                         end: { line: 1, column: 13 }
                     }
                 },
-                range: [2, 36],
+                range: [2, 13],
                 loc: {
                     start: { line: 1, column: 2 },
-                    end: { line: 2, column: 10 }
+                    end: { line: 1, column: 13 }
                 }
             }, {
                 type: 'ExpressionStatement',


### PR DESCRIPTION
When an statement is not terminated by a semicolon, the `consumeSemicolon` function terminates the `range`/`loc` of the node at the beginning of the next node, including any whitespace or comments trailing after the statement node. Instead, it should revert back to the end of the previous node.

If you look carefully at the test changes included in this commit (all of which I made by hand), I think you'll agree they make a lot of sense. The only ones I'm not sure about are the end-of-`Program` positions: for instance, the `Program` location for `'\n42\n\n'` now only includes the `42`, and not any of the whitespace. This was already true for the starting position, but now it is also true for the ending position.

This inclusion of trailing comments/whitespace by `consumeSemicolon` has been a very long-standing issue that I dealt with in https://github.com/benjamn/recast using the [`LocationFixer`](https://github.com/benjamn/recast/blob/6feb25024c6883bcfa027b95d3b5fa476ac179e9/lib/parser.js#L72-L101) class (first introduced in September 2012), but I want to stop using that class for performance reasons, and I've come to realize I can't correctly fix all cases anyway (I can rewind over whitespace, but not so easily over comments, without implementing something like `unskipComment`), so I believe this logic is better implemented in esprima.js.

https://code.google.com/p/esprima/issues/detail?id=574
