### PR TITLE
Remove spurious arguments to parseEmptyStatement and parseFunctionDeclaration.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3384,7 +3384,7 @@ parseStatement: true, parseSourceElement: true */
         if (type === Token.Punctuator) {
             switch (lookahead.value) {
             case ';':
-                return parseEmptyStatement(node);
+                return parseEmptyStatement();
             case '(':
                 return parseExpressionStatement(node);
             default:
@@ -3403,7 +3403,7 @@ parseStatement: true, parseSourceElement: true */
             case 'for':
                 return parseForStatement(node);
             case 'function':
-                return parseFunctionDeclaration(node);
+                return parseFunctionDeclaration();
             case 'if':
                 return parseIfStatement(node);
             case 'return':


### PR DESCRIPTION
This fixes https://code.google.com/p/esprima/issues/detail?id=579.