### PR TITLE
Add options.isModule

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -4864,7 +4864,7 @@ parseYieldExpression: true
     }
 
     function parseProgramElement() {
-        if (lookahead.type === Token.Keyword) {
+        if (extra.isModule && lookahead.type === Token.Keyword) {
             switch (lookahead.value) {
             case 'export':
                 return parseExportDeclaration();
@@ -4916,7 +4916,7 @@ parseYieldExpression: true
 
     function parseProgram() {
         var body, marker = markerCreate();
-        strict = false;
+        strict = !!extra.isModule;
         peek();
         body = parseProgramElements();
         return markerApply(marker, delegate.createProgram(body));
@@ -5369,6 +5369,9 @@ parseYieldExpression: true
                 });
             }
 
+            if (options.sourceType === 'module') {
+                extra.isModule = true;
+            }
             if (typeof options.tokens === 'boolean' && options.tokens) {
                 extra.tokens = [];
             }

--- a/test/harmonymodulestest.js
+++ b/test/harmonymodulestest.js
@@ -2317,10 +2317,16 @@ var modulesTestFixture = {
                 end: { line: 1, column: 33 }
             }
         }
-
     },
 
     'Modules Invalid Syntax': {
+        // Module top-levels are implicitly "use strict"
+        'with(someObj) {}': {
+            index: 0,
+            lineNumber: 1,
+            column: 1,
+            message: "Error: Line 1: Strict mode code may not include a with statement"
+        },
 
         'import foo': {
             index: 10,
@@ -2458,9 +2464,25 @@ var modulesTestFixture = {
             message: "Error: Line 1: Unexpected token ,",
             description: "Unexpected token ,"
         }
+    },
 
+    'Invalid Non-Modules Syntax': {
+        'export default 42;': {
+            index: 0,
+            lineNumber: 1,
+            column: 1,
+            message: "Error: Line 1: Unexpected reserved word",
+            description: "Unexpected reserved word"
+        },
+
+        'import foo from "foo";': {
+            index: 0,
+            lineNumber: 1,
+            column: 1,
+            message: "Error: Line 1: Unexpected reserved word",
+            description: "Unexpected reserved word"
+        }
     }
-
 };
 
 // Merge both test fixtures.
@@ -2469,7 +2491,9 @@ var modulesTestFixture = {
 
     'use strict';
 
-    var i, fixtures;
+    var i, fixtures, moduleFixtureOptions = {
+      sourceType: 'module'
+    };
 
     for (i in modulesTestFixture) {
         if (modulesTestFixture.hasOwnProperty(i)) {
@@ -2478,6 +2502,10 @@ var modulesTestFixture = {
                 throw new Error('Harmony test should not replace existing test for ' + i);
             }
             testFixture[i] = fixtures;
+
+            if (i !== 'Invalid Non-Modules Syntax') {
+                testFixtureOptions[i] = moduleFixtureOptions;
+            }
         }
     }
 

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -12229,9 +12229,7 @@ var harmonyTestFixture = {
         }
     },
 
-
     'Harmony Invalid syntax': {
-
         '0o': {
             index: 2,
             lineNumber: 1,
@@ -12476,8 +12474,6 @@ var harmonyTestFixture = {
             column: 7,
             message: 'Error: Line 1: Unexpected token default'
         },
-
-
 
         '({ v: eval }) = obj': {
             index: 13,
@@ -13278,7 +13274,6 @@ var harmonyTestFixture = {
             column: 7,
             message: 'Error: Line 1: Invalid left-hand side in assignment'
         }
-
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,8 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+var testFixtureOptions = {};
+
 var testFixture = {
 
     'Primary Expression': {


### PR DESCRIPTION
Currently esprima will parse module syntax (massive thanks to https://github.com/ariya/esprima/pull/287 !!), but it doesn't differentiate between module code and non-module code.

To remain spec-compliant, differentiating these two contexts is important for two reasons:
1) Module code is implicitly strict mode
2) Module code allows for `ExportDeclaration` and `ImportDeclaration` at the top-level, whereas non-modules do not

This change adds an `isModule` flag to the options object (passed to `esprima.parse()`) to indicate whether the source is intended to represent a module vs a non-module (aka "script"). The option defaults to `false` to remain backward compatible (and since 99.9% of JS code in the world is a non-module, so this is a pretty sane default). 

cc @caridy

https://code.google.com/p/esprima/issues/detail?id=598
