### PR TITLE
Added test for escaped quotes in strings, which currently doesn't work

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -6348,6 +6348,25 @@ var testFixture = {
             }
         },
 
+        '"\""': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'Literal',
+                value: '"',
+                raw: '"\""',
+                range: [0, 4],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 4 }
+                }
+            },
+            range: [0, 4],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 4 }
+            }
+        },
+
         '"\\n\\r\\t\\v\\b\\f\\\\\\\'\\"\\0"': {
             type: 'ExpressionStatement',
             expression: {


### PR DESCRIPTION
`esprima.parse('"\""')` causes:
  Error: Line 1: Unexpected token ILLEGAL

Ticket: https://code.google.com/p/esprima/issues/detail?id=608
