### PR TITLE
Change where comments are attached back to 1.2 branch location.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1618,11 +1618,8 @@ parseYieldExpression: true
         }
 
         // Eating the stack.
-        if (last) {
-            while (last && last.range[0] >= node.range[0]) {
-                lastChild = last;
-                last = bottomRight.pop();
-            }
+        while (bottomRight.length > 0 && bottomRight[bottomRight.length - 1].range[0] >= node.range[0]) {
+            lastChild = bottomRight.pop();
         }
 
         if (lastChild) {

--- a/test/test.js
+++ b/test/test.js
@@ -3754,6 +3754,67 @@ var testFixture = {
             }
         },
 
+        'var o = {\n/** Desc */\nfoo: function(){}\n};': {
+            "type": "Program",
+            "body": [{
+                "type": "VariableDeclaration",
+                "declarations": [{
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "o",
+                        "range": [4, 5]
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [{
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "foo",
+                                    "range": [22, 25]
+                                },
+                                "value": {
+                                    "type": "FunctionExpression",
+                                    "id": null,
+                                    "params": [],
+                                    "defaults": [],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [],
+                                        "range": [37, 39]
+                                    },
+                                    "rest": null,
+                                    "generator": false,
+                                    "expression": false,
+                                    "range": [27, 39]
+                                },
+                                "kind": "init",
+                                method: false,
+                                shorthand: false,
+                                computed: false,
+                                "range": [22, 39],
+                                "leadingComments": [{
+                                    "type": "Block",
+                                    "value": "* Desc ",
+                                    "range": [10, 21]
+                                }],
+                        }],
+                        "range": [8, 41]
+                    },
+                    "range": [4, 41]
+                }],
+                "kind": "var",
+                "range": [0, 42]
+            }],
+            "range": [0, 42],
+            "comments": [{
+                "type": "Block",
+                "value": "* Desc ",
+                "range": [10, 21]
+            }]
+        },
+
         'function foo(){}\n//comment\nfunction bar(){}': {
             type: "Program",
             body: [{


### PR DESCRIPTION
https://code.google.com/p/esprima/issues/detail?id=607

This logic is the same as the 1.2 branch stack eating logic, it results in
comment nodes being placed where tools like ESLint expect them to exist.