### PR TITLE
[master] Remove the upper limit of hex digits in Unicode code point escapes

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1072,11 +1072,20 @@ parseStatement: true, parseSourceElement: true */
 
         if (flags.indexOf('u') >= 0) {
             // Replace each astral symbol and every Unicode code point
-            // escape sequence that represents such a symbol with a single
-            // ASCII symbol to avoid throwing on regular expressions that
-            // are only valid in combination with the `/u` flag.
+            // escape sequence with a single ASCII symbol to avoid throwing on
+            // regular expressions that are only valid in combination with the
+            // `/u` flag.
+            // Note: replacing with the ASCII symbol `x` might cause false
+            // negatives in unlikely scenarios. For example, `[\u{61}-b]` is a
+            // perfectly valid pattern that is equivalent to `[a-b]`, but it
+            // would be replaced by `[x-b]` which throws an error.
             tmp = tmp
-                .replace(/\\u\{([0-9a-fA-F]{5,6})\}/g, 'x')
+                .replace(/\\u\{([0-9a-fA-F]+)\}/g, function ($0, $1) {
+                    if (parseInt($1, 16) <= 0x10FFFF) {
+                        return 'x';
+                    }
+                    throwError({}, Messages.InvalidRegExp);
+                })
                 .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, 'x');
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -6697,7 +6697,7 @@ var testFixture = {
             type: 'ExpressionStatement',
             expression: {
                 type: 'Literal',
-                value: '煎茶',
+                value: '\u714E\u8336',
                 raw: '"\\u{714E}\\u{8336}"',
                 range: [0, 18],
                 loc: {
@@ -6728,6 +6728,25 @@ var testFixture = {
             loc: {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 27 }
+            }
+        },
+
+        '"\\u{00000000034}"': {
+            type: 'ExpressionStatement',
+            expression: {
+                range: [0, 17],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 17 }
+                },
+                type: 'Literal',
+                value: '4',
+                raw: '"\\u{00000000034}"'
+            },
+            range: [0, 17],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 17 }
             }
         }
 
@@ -6991,6 +7010,99 @@ var testFixture = {
                     end: { line: 1, column: 16 }
                 }
             }]
+        },
+
+        'var x = /[\\u{0000000000000061}-\\u{7A}]/u': {
+            type: 'Program',
+            body: [{
+                type: 'VariableDeclaration',
+                declarations: [{
+                    type: 'VariableDeclarator',
+                    id: {
+                        type: 'Identifier',
+                        name: 'x',
+                        range: [4, 5],
+                        loc: {
+                            start: { line: 1, column: 4 },
+                            end: { line: 1, column: 5 }
+                        }
+                    },
+                    init: {
+                        type: 'Literal',
+                        value: null,
+                        raw: '/[\\u{0000000000000061}-\\u{7A}]/u',
+                        regex: {
+                            pattern: '[\\u{0000000000000061}-\\u{7A}]',
+                            flags: 'u'
+                        },
+                        range: [8, 40],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 40 }
+                        }
+                    },
+                    range: [4, 40],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 40 }
+                    }
+                }],
+                kind: 'var',
+                range: [0, 40],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 40 }
+                }
+            }],
+            range: [0, 40],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 40 }
+            },
+            tokens: [{
+                type: 'Keyword',
+                value: 'var',
+                range: [0, 3],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 3 }
+                }
+            }, {
+                type: 'Identifier',
+                value: 'x',
+                range: [4, 5],
+                loc: {
+                    start: { line: 1, column: 4 },
+                    end: { line: 1, column: 5 }
+                }
+            }, {
+                type: 'Punctuator',
+                value: '=',
+                range: [6, 7],
+                loc: {
+                    start: { line: 1, column: 6 },
+                    end: { line: 1, column: 7 }
+                }
+            }, {
+                type: 'RegularExpression',
+                value: '/[\\u{0000000000000061}-\\u{7A}]/u',
+                regex: {
+                    pattern: '[\\u{0000000000000061}-\\u{7A}]',
+                    flags: 'u'
+                },
+                range: [8, 40],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 40 }
+                }
+            }]
+        },
+
+        'var x = /\\u{110000}/u': {
+            index: 21,
+            lineNumber: 1,
+            column: 22,
+            message: 'Error: Line 1: Invalid regular expression'
         },
 
         'var x = /[x-z]/i': {


### PR DESCRIPTION
E.g. `'\u{00000000000000000001D306}' == '\u{1D306}'`. This was already implemented correctly for string literals, but the code for regular expressions only supported up to 6 hexadecimal digits. This patch fixes that and adds tests for this behavior. I’ve also added a comment that explains the downsides of the hacky way we test if a regular expression is valid (but AFAICT there is no reasonable other way to do it without implementing a full JS regexp parser in Esprima).

https://code.google.com/p/esprima/issues/detail?id=612

This is the patch for the **master** branch. See #294 for the patch for the harmony branch.
