### PR TITLE
Make tools/generate-test-fixture.js take a -m/--module option for `sourceType="module"` mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "complexity-report": "~0.6.1",
         "regenerate": "~0.5.4",
         "unicode-6.3.0": "~0.1.0",
-        "json-diff": "~0.3.1"
+        "json-diff": "~0.3.1",
+        "commander": "~2.5.0"
     },
     "scripts": {
         "test": "npm run-script lint && node test/run.js && npm run-script coverage && npm run-script complexity",

--- a/tools/generate-test-fixture.js
+++ b/tools/generate-test-fixture.js
@@ -33,9 +33,17 @@
         path = require('path'),
         root = path.join(path.dirname(fs.realpathSync(__filename)), '..'),
         esprima = require(path.join(root, 'esprima')),
-        code = process.argv.splice(2),
+        code,
         content,
         options;
+
+    var cliArgs = require('commander')
+      .option('-m, --module', 'Parse source as a module (rather than as a script)')
+      .parse(process.argv);
+
+    code = cliArgs.args[0];
+
+    console.log('code', code);
 
     if (code.length === 0) {
         console.log('Usage:');
@@ -307,7 +315,7 @@
         return str('', top);
     }
 
-    content = code[0];
+    content = code;
 
     options = {
         comment: false,
@@ -315,7 +323,8 @@
         loc: true,
         tokens: false,
         raw: true,
-        tolerant: false
+        tolerant: false,
+        sourceType: cliArgs.module ? 'module' : 'script'
     };
 
     console.log(stringify(esprima.parse(content, options)));


### PR DESCRIPTION
Currently the `tools/generate-test-fixture.js` utility is incapable of parsing module-only syntax (like import/export).
This adds a `--module` or `-m` flag to that script to put esprima into `sourceType="module"` mode when parsing

https://code.google.com/p/esprima/issues/detail?id=614
