### PR TITLE
Fix parsing of `import {} from "A";` and `export {};`

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3658,10 +3658,12 @@ parseYieldExpression: true
         }
 
         expect('{');
-        do {
-            isExportFromIdentifier = isExportFromIdentifier || matchKeyword('default');
-            specifiers.push(parseExportSpecifier());
-        } while (match(',') && lex());
+        if (!match('}')) {
+            do {
+                isExportFromIdentifier = isExportFromIdentifier || matchKeyword('default');
+                specifiers.push(parseExportSpecifier());
+            } while (match(',') && lex());
+        }
         expect('}');
 
         if (matchContextualKeyword('from')) {
@@ -3702,9 +3704,11 @@ parseYieldExpression: true
         var specifiers = [];
         // {foo, bar as bas}
         expect('{');
-        do {
-            specifiers.push(parseImportSpecifier());
-        } while (match(',') && lex());
+        if (!match('}')) {
+            do {
+                specifiers.push(parseImportSpecifier());
+            } while (match(',') && lex());
+        }
         expect('}');
         return specifiers;
     }

--- a/test/harmonymodulestest.js
+++ b/test/harmonymodulestest.js
@@ -2463,6 +2463,39 @@ var modulesTestFixture = {
             column: 16,
             message: "Error: Line 1: Unexpected token ,",
             description: "Unexpected token ,"
+        },
+
+        'import {} from "foo";': {
+            type: 'ImportDeclaration',
+            specifiers: [],
+            source: {
+                type: 'ModuleSpecifier',
+                value: 'foo',
+                raw: '"foo"',
+                range: [15, 20],
+                loc: {
+                    start: { line: 1, column: 15 },
+                    end: { line: 1, column: 20 }
+                }
+            },
+            range: [0, 21],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 21 }
+            }
+        },
+
+        'export {};': {
+            type: 'ExportDeclaration',
+            'default': false,
+            declaration: null,
+            specifiers: [],
+            source: null,
+            range: [0, 10],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 10 }
+            }
         }
     },
 


### PR DESCRIPTION
Previously empty import/export specifier lists wouldn't parse -- even though this is allowed in the spec:

https://people.mozilla.org/~jorendorff/es6-draft.html#sec-imports
https://people.mozilla.org/~jorendorff/es6-draft.html#sec-exports

This fixes the parser to allow empty import/export specifier lists

https://code.google.com/p/esprima/issues/detail?id=615
