### PR TITLE
Remove extraneous console.log() from tools/generate-test-fixtures.js

### DIFF
--- a/tools/generate-test-fixture.js
+++ b/tools/generate-test-fixture.js
@@ -43,8 +43,6 @@
 
     code = cliArgs.args[0];
 
-    console.log('code', code);
-
     if (code.length === 0) {
         console.log('Usage:');
         console.log('   generate-test-fixture.js code');


### PR DESCRIPTION
I forgot to remove this debugging stuffs from #295  before it got merged.
