### PR TITLE
Fixes #1008: Better peekLineTerminator

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -23528,9 +23528,9 @@ var testFixture = {
         },
 
         '(function () { \'use strict\'; with (i); }())': {
-            index: 29,
+            index: 28,
             lineNumber: 1,
-            column: 30,
+            column: 29,
             message: 'Error: Line 1: Strict mode code may not include a with statement'
         },
 
@@ -24050,6 +24050,13 @@ var testFixture = {
             lineNumber: 1,
             column: 22,
             message: 'Error: Line 1: Unexpected end of input'
+        },
+
+        '\'use strict\'; a package': {
+            index: 16,
+            lineNumber: 1,
+            column: 17,
+            message: 'Error: Line 1: Use of future reserved word in strict mode'
         }
 
     },
@@ -26927,9 +26934,9 @@ var testFixture = {
                 end: { line: 1, column: 43 }
             },
             errors: [{
-                index: 29,
+                index: 28,
                 lineNumber: 1,
-                column: 30,
+                column: 29,
                 message: 'Error: Line 1: Strict mode code may not include a with statement'
             }]
         },


### PR DESCRIPTION
Fixes #1008: Do not call `skipComment` when peeking for line terminators.
This also serves as a stepping stone for #1009.

This pull request is to change the current behavior of peeking for the line terminators. Currently in the parser part (`parseXXXX` functions) `index`, `lineNumber` and `lineStart` points to the end of the previous token or to the beginning of the input, unless an explicit `skipComment` call is made and it will point to the beginning of `lookahead`. Each time we peek for the line terminator we need to `skipComment` again which is shown to be very expensive in the profiling in Chrome.

This change will add several new location cursors `startIndex`, `startLineNumber`, `startLineStart` to point to the beginning of `lookahead`. `index`, `lineNumber` and `lineStart` will point to the end of the `lookahead` instead. In `lex` and `peek`, `index` is never assigned back to the end of the last token.

In order to peek for the line terminator, another flag `hasLineTerminator` is introduced and `peekLineTerminator` function is removed. `hasLineTerminator` flag is updated in `skipComment` and the same whitespace area is never scanned twice. This has extra benefits in `comment` or `attacheComment` flags are on. Also, since `startIndex` is now pointing add the beginning of the `lookahead`, `parseSourceElement` need not to return `undefined` anymore and there's no need to check for its result anymore.

Result with `range` and `loc` off (+**17%**):
```
master:
    Underscore 1.5.2    42.5 KiB      2.85 ms ± 1.13%
      Backbone 1.1.0    58.7 KiB      3.07 ms ± 0.81%
      MooTools 1.4.5   156.7 KiB     13.89 ms ± 1.24%
        jQuery 1.9.1   262.1 KiB     17.34 ms ± 0.82%
          YUI 3.12.0   330.4 KiB     14.23 ms ± 0.94%
 jQuery.Mobile 1.4.2   442.2 KiB     32.13 ms ± 1.25%
       Angular 1.2.5   701.7 KiB     30.54 ms ± 2.16%
                     ------------------------
                      1994.3 KiB    114.06 ms ± 1.46%

better-peek-line-terminator:
    Underscore 1.5.2    42.5 KiB      2.70 ms ± 0.95%
      Backbone 1.1.0    58.7 KiB      2.62 ms ± 0.83%
      MooTools 1.4.5   156.7 KiB     11.62 ms ± 0.94%
        jQuery 1.9.1   262.1 KiB     16.02 ms ± 1.51%
          YUI 3.12.0   330.4 KiB     11.22 ms ± 0.94%
 jQuery.Mobile 1.4.2   442.2 KiB     25.12 ms ± 0.94%
       Angular 1.2.5   701.7 KiB     27.98 ms ± 1.92%
                     ------------------------
                      1994.3 KiB     97.29 ms ± 1.38%
```

Result with `range` and `loc` on (**not significant**):
```
master:
    Underscore 1.5.2    42.5 KiB      3.50 ms ± 1.01%
      Backbone 1.1.0    58.7 KiB      3.40 ms ± 0.91%
      MooTools 1.4.5   156.7 KiB     18.40 ms ± 0.91%
        jQuery 1.9.1   262.1 KiB     18.64 ms ± 0.89%
          YUI 3.12.0   330.4 KiB     19.00 ms ± 1.13%
 jQuery.Mobile 1.4.2   442.2 KiB     81.15 ms ± 7.25%
       Angular 1.2.5   701.7 KiB     59.75 ms ± 7.54%
                     ------------------------
                      1994.3 KiB    203.84 ms ± 6.15%

better-peek-line-terminator:
    Underscore 1.5.2    42.5 KiB      3.33 ms ± 2.08%
      Backbone 1.1.0    58.7 KiB      3.30 ms ± 1.03%
      MooTools 1.4.5   156.7 KiB     18.10 ms ± 1.18%
        jQuery 1.9.1   262.1 KiB     17.98 ms ± 1.15%
          YUI 3.12.0   330.4 KiB     18.06 ms ± 1.05%
 jQuery.Mobile 1.4.2   442.2 KiB     79.93 ms ± 7.95%
       Angular 1.2.5   701.7 KiB     60.65 ms ± 7.81%
                     ------------------------
                      1994.3 KiB    201.35 ms ± 6.62%
```

