### PR TITLE
Make `testRegExp` less restrictive

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1089,10 +1089,11 @@
         var tmp = pattern;
 
         if (flags.indexOf('u') >= 0) {
-            // Replace each astral symbol and every Unicode code point
-            // escape sequence with a single ASCII symbol to avoid throwing on
-            // regular expressions that are only valid in combination with the
-            // `/u` flag.
+            // Replace each astral symbol and every Unicode escape sequence
+            // that possibly represents an astral symbol or a paired surrogate
+            // with a single ASCII symbol to avoid throwing on regular
+            // expressions that are only valid in combination with the `/u`
+            // flag.
             // Note: replacing with the ASCII symbol `x` might cause false
             // negatives in unlikely scenarios. For example, `[\u{61}-b]` is a
             // perfectly valid pattern that is equivalent to `[a-b]`, but it
@@ -1104,7 +1105,10 @@
                     }
                     throwUnexpectedToken(null, Messages.InvalidRegExp);
                 })
-                .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, 'x');
+                .replace(
+                    /\\u([a-fA-F0-9]{4})|[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
+                    'x'
+                );
         }
 
         // First, detect invalid regular expressions.

--- a/test/fixtures/expression/primary/literal/regular-expression/u-flag-surrogate-pair.js
+++ b/test/fixtures/expression/primary/literal/regular-expression/u-flag-surrogate-pair.js
@@ -1,0 +1,1 @@
+var x = /[\uD834\uDF06-\uD834\uDF08a-z]/u

--- a/test/fixtures/expression/primary/literal/regular-expression/u-flag-surrogate-pair.tree.json
+++ b/test/fixtures/expression/primary/literal/regular-expression/u-flag-surrogate-pair.tree.json
@@ -1,0 +1,175 @@
+{
+    "type": "Program",
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "x",
+                        "range": [
+                            4,
+                            5
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 5
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "value": null,
+                        "raw": "/[\\uD834\\uDF06-\\uD834\\uDF08a-z]/u",
+                        "regex": {
+                            "pattern": "[\\uD834\\uDF06-\\uD834\\uDF08a-z]",
+                            "flags": "u"
+                        },
+                        "range": [
+                            8,
+                            41
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 41
+                            }
+                        }
+                    },
+                    "range": [
+                        4,
+                        41
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 41
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                0,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 41
+                }
+            }
+        }
+    ],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "range": [
+                0,
+                3
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "x",
+            "range": [
+                4,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                6,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "RegularExpression",
+            "value": "/[\\uD834\\uDF06-\\uD834\\uDF08a-z]/u",
+            "regex": {
+                "pattern": "[\\uD834\\uDF06-\\uD834\\uDF08a-z]",
+                "flags": "u"
+            },
+            "range": [
+                8,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 41
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        41
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 41
+        }
+    }
+}


### PR DESCRIPTION
E.g.

```js
/[\uD834\uDF06-\uD834\uDF08a-z]/u
```

This is perfectly valid ES6 (given the `u` flag) but it didn’t parse in Esprima before this patch because `testRegExp` evaluates the regexp without the `u` flag (as it should, since it aims to support a wide range of browsers/environments).

This patch accounts for this case as well by using a regex to look for `\uXXXX` escape sequences and replacing them with a hardcoded ASCII letter `x` (like we previously did for `\u{…}` escapes).

Note: this still doesn’t handle all cases (but really, we’d need a regular expression parser to do that properly), e.g. when the high surrogate is represented by an escape sequence but the low surrogate is the raw character, but such cases are extremely rare to non-existent. 