### PR TITLE
Simplify the logic to handle unclosed block comment.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -452,20 +452,16 @@
             }
         }
 
-        if (extra.errors && index >= length) {
-            //ran off the end of the file - the whole thing is a comment
-            if (extra.comments) {
-                loc.end = {
-                    line: lineNumber,
-                    column: index - lineStart
-                };
-                comment = source.slice(start + 2, index);
-                addComment('Block', comment, start, index, loc);
-            }
-            tolerateUnexpectedToken();
-        } else {
-            throwUnexpectedToken();
+        // Ran off the end of the file - the whole thing is a comment
+        if (extra.comments) {
+            loc.end = {
+                line: lineNumber,
+                column: index - lineStart
+            };
+            comment = source.slice(start + 2, index);
+            addComment('Block', comment, start, index, loc);
         }
+        tolerateUnexpectedToken();
     }
 
     function skipComment() {


### PR DESCRIPTION
There is no need to check for EOF here because it is implied when
the previous while loop terminates.

Refs #1041