### PR TITLE
Octal literals are not allowed in template strings

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -1366,8 +1366,7 @@
     }
 
     function testRegExp(pattern, flags) {
-        var tmp = pattern,
-            value;
+        var tmp = pattern;
 
         if (flags.indexOf('u') >= 0) {
             // Replace each astral symbol and every Unicode code point
@@ -1390,7 +1389,7 @@
 
         // First, detect invalid regular expressions.
         try {
-            value = new RegExp(tmp);
+            RegExp(tmp);
         } catch (e) {
             throwError({}, Messages.InvalidRegExp);
         }
@@ -5165,7 +5164,6 @@
 
     function tokenize(code, options) {
         var toString,
-            token,
             tokens;
 
         toString = String;
@@ -5222,12 +5220,11 @@
                 return extra.tokens;
             }
 
-            token = lex();
+            lex();
             while (lookahead.type !== Token.EOF) {
                 try {
-                    token = lex();
+                    lex();
                 } catch (lexError) {
-                    token = lookahead;
                     if (extra.errors) {
                         extra.errors.push(lexError);
                         // We have to break on the first error

--- a/test/harmonytest.js
+++ b/test/harmonytest.js
@@ -1101,34 +1101,34 @@ var harmonyTestFixture = {
             }
         },
 
-        '`\\u{000042}\\u0042\\x42\\u0\\102\\A`': {
+        '`\\u{000042}\\u0042\\x42\\u0\\A\\0`': {
             type: 'ExpressionStatement',
             expression: {
                 type: 'TemplateLiteral',
                 quasis: [{
                     type: 'TemplateElement',
                     value: {
-                        raw: '\\u{000042}\\u0042\\x42\\u0\\102\\A',
-                        cooked: 'BBBu0BA'
+                        raw: '\\u{000042}\\u0042\\x42\\u0\\A\\0',
+                        cooked: 'BBBu0A\u0000'
                     },
                     tail: true,
-                    range: [0, 31],
+                    range: [0, 29],
                     loc: {
                         start: { line: 1, column: 0 },
-                        end: { line: 1, column: 31 }
+                        end: { line: 1, column: 29 }
                     }
                 }],
                 expressions: [],
-                range: [0, 31],
+                range: [0, 29],
                 loc: {
                     start: { line: 1, column: 0 },
-                    end: { line: 1, column: 31 }
+                    end: { line: 1, column: 29 }
                 }
             },
-            range: [0, 31],
+            range: [0, 29],
             loc: {
                 start: { line: 1, column: 0 },
-                end: { line: 1, column: 31 }
+                end: { line: 1, column: 29 }
             }
         },
 
@@ -16173,10 +16173,10 @@ var harmonyTestFixture = {
         },
 
         '"use strict"; `${test}\\02`;': {
-            index: 21,
+            index: 25,
             lineNumber: 1,
-            column: 22,
-            message: 'Error: Line 1: Octal literals are not allowed in strict mode.'
+            column: 26,
+            message: 'Error: Line 1: Octal literals are not allowed in template strings.'
         },
 
         '[...a, ] = b': {


### PR DESCRIPTION
As discussed in #1121, legacy octal literals are strictly forbidden in template strings, as per 11.8.6 and 16.1