### PR TITLE
Travis CI test: exclude Node.js v0.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ script: "npm run travis"
 node_js:
   - iojs
   - "0.12"
-  - "0.11"
   - "0.10"
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "esprima.js"
     ],
     "engines": {
-        "node": ">=0.4.0"
+        "node": ">=0.10.0"
     },
     "author": {
         "name": "Ariya Hidayat",


### PR DESCRIPTION
It is considered unstable, superceded by the stable v0.12.
And since the tests only run on v0.10 or later, that's what should be
claimed in package.json.