### PR TITLE
Yield expression without an expression should have a null argument.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -3759,6 +3759,7 @@
     function parseYieldExpression() {
         var argument, expr, delegate, previousAllowYield;
 
+        argument = null;
         expr = new Node();
 
         expectKeyword('yield');

--- a/test/fixtures/ES6/generator/generator-method-with-yield-line-terminator.tree.json
+++ b/test/fixtures/ES6/generator/generator-method-with-yield-line-terminator.tree.json
@@ -150,7 +150,8 @@
                                                     "column": 7
                                                 }
                                             },
-                                            "type": "YieldExpression"
+                                            "type": "YieldExpression",
+                                            "argument": null
                                         }
                                     },
                                     {

--- a/test/fixtures/ES6/generator/generator-method-with-yield.tree.json
+++ b/test/fixtures/ES6/generator/generator-method-with-yield.tree.json
@@ -151,6 +151,7 @@
                                                 }
                                             },
                                             "type": "YieldExpression",
+                                            "argument": null,
                                             "delegate": false
                                         }
                                     }

--- a/test/fixtures/ES6/yield/yield-yield-expression-delegate.tree.json
+++ b/test/fixtures/ES6/yield/yield-yield-expression-delegate.tree.json
@@ -116,6 +116,7 @@
                                     }
                                 },
                                 "type": "YieldExpression",
+                                "argument": null,
                                 "delegate": false
                             },
                             "delegate": true

--- a/test/fixtures/ES6/yield/yield-yield-expression.tree.json
+++ b/test/fixtures/ES6/yield/yield-yield-expression.tree.json
@@ -116,6 +116,7 @@
                                     }
                                 },
                                 "type": "YieldExpression",
+                                "argument": null,
                                 "delegate": false
                             },
                             "delegate": false


### PR DESCRIPTION
Fixes #1223