### PR TITLE
Add tools/generate-fixtures.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+test/dist

--- a/package.json
+++ b/package.json
@@ -34,15 +34,16 @@
     },
     "license": "BSD-2-Clause",
     "devDependencies": {
-        "eslint": "~0.23.0",
-        "jscs": "~1.13.1",
-        "istanbul": "~0.3.16",
+        "coveralls": "~2.11.2",
         "escomplex-js": "1.2.0",
-        "regenerate": "~0.6.2",
-        "unicode-7.0.0": "~0.1.5",
+        "eslint": "~0.23.0",
+        "glob": "^5.0.14",
+        "istanbul": "~0.3.16",
+        "jscs": "~1.13.1",
         "json-diff": "~0.3.1",
         "node-tick-processor": "~0.0.2",
-        "coveralls": "~2.11.2"
+        "regenerate": "~0.6.2",
+        "unicode-7.0.0": "~0.1.5"
     },
     "keywords": [
         "ast",
@@ -77,6 +78,7 @@
         "downstream": "node test/downstream.js",
         "travis": "npm test && npm run coveralls && npm run downstream",
 
-        "generate-regex": "node tools/generate-identifier-regex.js"
+        "generate-regex": "node tools/generate-identifier-regex.js",
+        "generate-fixtures": "node tools/generate-fixtures.js"
     }
 }

--- a/tools/generate-fixtures.js
+++ b/tools/generate-fixtures.js
@@ -1,0 +1,69 @@
+/*
+  Copyright (c) jQuery Foundation, Inc. and Contributors, All Rights Reserved.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+    Reads the fixture files in `test/fixtures` and writes
+    two aggregate fixture files (`test/dist/fixtures_js.js` and `test/dist/fixtures_json.js`)
+*/
+
+'use strict';
+
+var fs = require('fs'),
+    glob = require("glob"),
+    path = require('path'),
+    fixturePath = 'test/fixtures',
+    fixtureDist = 'test/dist';
+
+function renderFixturesFile(ext, stringify) {
+    var fixtureFilePaths, fixtures, content, fixtureDistPath;
+
+    function renderFixture(filePath) {
+        var content, relativeFilePath, key, value;
+
+        content = fs.readFileSync(filePath, 'utf-8');
+        relativeFilePath = path.relative(fixturePath, filePath);
+        key = relativeFilePath.substring(0, relativeFilePath.length - ext.length - 1);
+        value = stringify ? JSON.stringify(content) : content;
+
+        return "fixtures_" + ext + "['" + key + "'] = " + value + ";";
+    };
+
+    function templateFixtureFile(fixtures) {
+        var content = "";
+        content += "var fixtures_" + ext + " = {};\n";
+        content += fixtures;
+        content += "module.exports = fixtures_" + ext;
+
+        return content;
+    }
+
+    fixtureFilePaths = glob.sync(path.join(__dirname, '../' + fixturePath + '/**/*.' + ext));
+    fixtures = fixtureFilePaths.map(renderFixture).join('\n');
+    content = templateFixtureFile(fixtures);
+
+    fixtureDistPath = path.join(fixtureDist, 'fixtures_' + ext + '.js');
+    fs.writeFileSync(fixtureDistPath, content);
+
+    console.log('built', fixtureDistPath);
+}
+
+renderFixturesFile('js', true);
+renderFixturesFile('json', false);


### PR DESCRIPTION
The tool reads the js and json fixtures and builds two fixture files.

I added two npm packages as devDependencies `lodash` and `glob`. They're
both pretty minor and I don't feel strongly about either.

Here are the two resulting gists:
https://gist.github.com/50f41ee3d919b4d76759
https://gist.github.com/7c16f3f107ab805f0993