### PR TITLE
Add browser test runner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,34 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['mocha'],
+
+    files: [
+      'esprima.js',
+      'node_modules/lodash/index.js',
+      'test/dist/fixtures_js.js',
+      'test/dist/fixtures_json.js',
+      'test/utils/evaluate-testcase.js',
+      'test/browser-tests.js',
+    ],
+
+    exclude: [],
+
+    client: {
+      mocha: {
+        reporter: 'html', // change Karma's debug.html to the mocha web reporter
+        ui: 'bdd'
+      }
+    },
+
+    reporters: ['dots'], // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_WARN, // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    autoWatch: true,
+    singleRun: false,
+
+    browsers: ['Chrome'], // ['PhantomJS'],
+
+  });
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
         "istanbul": "~0.3.16",
         "jscs": "~1.13.1",
         "json-diff": "~0.3.1",
+        "karma": "^0.13.3",
+        "karma-chrome-launcher": "^0.2.0",
+        "karma-mocha": "^0.2.0",
+        "lodash": "^3.10.0",
+        "mocha": "^2.2.5",
         "node-tick-processor": "~0.0.2",
         "regenerate": "~0.6.2",
         "unicode-7.0.0": "~0.1.5"
@@ -63,6 +68,7 @@
         "unit-tests": "node test/unit-tests.js",
         "regression-tests": "node test/regression-tests.js",
         "tests": "npm run unit-tests && npm run regression-tests",
+        "browser-tests": "karma start",
 
         "analyze-coverage": "istanbul cover test/unit-tests.js",
         "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -1,0 +1,183 @@
+/*
+  Copyright (c) jQuery Foundation, Inc. and Contributors, All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+'use strict';
+
+/**
+ * Reads jsFixtures and jsonFixtures into cases dictionary
+ */
+function createTestCases(jsFixtures, jsonFixtures) {
+    var cases = {};
+
+    function addCase(key, kind, item) {
+        if (!cases[key]) {
+            cases[key] = { key: key };
+        }
+
+        cases[key][kind] = item;
+    }
+
+    function addJsonFixture(value, filePath) {
+        /**
+         * Determines which type of test it is based on the filepath
+         */
+        function getType() {
+            return _(['module', 'tree', 'tokens', 'failure', 'result']).find(function (type) {
+                var suffix = '.' + type;
+                return (filePath.slice(-suffix.length) === suffix);
+            });
+        }
+
+        function getKey() {
+            return filePath.slice(0, -getType().length - 1)
+        }
+
+        function getValue() {
+            return value;
+        }
+
+        return addCase(getKey(), getType(), getValue());
+    }
+
+    function addJSFixture(value, filePath) {
+        /**
+         * checks to see if filepath is a run or source type.
+         */
+        function checkType(type) {
+            var suffix = '.' + type;
+            return filePath.slice(-suffix.length) === suffix
+        }
+
+        /**
+         * builds a case key by stripping away the type
+         */
+        function getKey(type) {
+            return filePath.slice(0, -type.length - 1)
+        }
+
+        /**
+         * returns the js test case.
+         * In the case of source tests, the input needs to be evaluated.
+         */
+        function getValue(value, shouldEval) {
+            var source, newValue;
+
+            if (shouldEval) {
+                // strip away the `var` in `var source = "foo"`.
+                eval(value.substring(4));
+                newValue = source;
+            } else {
+                newValue = value;
+            }
+
+            return newValue;
+        }
+
+        if (checkType('run')) {
+            return addCase(getKey('run'), 'run', getValue(value));
+        }
+
+        if (checkType('source')) {
+            return addCase(getKey('source'), 'source', getValue(value, true));
+        }
+
+        return addCase(filePath, 'case', getValue(value));
+    }
+
+    _.each(jsFixtures, addJSFixture);
+    _.each(jsonFixtures, addJsonFixture);
+    return cases;
+}
+
+/**
+ * Loops over the test cases and uses mocha `describe` and `it`
+ * to run through the tests.
+ */
+function browserRunner(cases) {
+    var keys, tree;
+
+    /**
+     * Takes a list of file paths and returns a tree, that will be
+     * used to create the nested describes.
+     */
+    function buildTree(keys) {
+        var subTrees;
+
+        function firstPart(key) {
+            return key.split('/')[0];
+        }
+
+        function dropFirst(key) {
+            return _.drop(key.split('/')).join('/');
+        }
+
+        if (keys[0] == "") {
+            return null;
+        }
+
+        subTrees = _.groupBy(keys, firstPart);
+        return _.mapValues(subTrees, function (keys, key) {
+            keys = _.map(keys, dropFirst);
+            return buildTree(keys);
+        });
+    }
+
+    function describeTests(tree, path) {
+        var tests, testDirectory;
+
+        // Create `it` for tests
+        tests = _.omit(tree, _.isObject);
+        _.each(_.keys(tests), function (testPath) {
+            var testCases = _.omit(cases, function (testCase, key) {
+                return !_.contains(key, path + "/" + testPath);
+            })
+
+            _.each(testCases, function (testCase) {
+                var source, testCaseCase, name;
+
+                source = testCase.source || '';
+                testCaseCase = testCase.case || '';
+                name = testCase.key + " - " + source  + testCaseCase;
+
+                it(name, function () {
+                    evaluateTestCase(testCase);
+                });
+            });
+        })
+
+        // Create `describe` for test directories
+        testDirectory = _.omit(tree, _.isNull);
+        _.each(testDirectory, function (subTree, key) {
+            describe(key, function () {
+                var newPath = path != "" ? path + "/" + key : key;
+                describeTests(subTree, newPath)
+            })
+        })
+    }
+
+    describeTests(buildTree(_.keys(cases)), '');
+}
+
+var cases = createTestCases(window.fixtures_js, window.fixtures_json);
+browserRunner(cases);

--- a/test/utils/evaluate-testcase.js
+++ b/test/utils/evaluate-testcase.js
@@ -1,0 +1,351 @@
+/*
+  Copyright (c) jQuery Foundation, Inc. and Contributors, All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+'use strict';
+
+// TODO: Unify with unit-tests test helpers.
+
+function NotMatchingError(expected, actual) {
+    Error.call(this, 'Expected ');
+    this.expected = expected;
+    this.actual = actual;
+}
+NotMatchingError.prototype = new Error();
+
+function assertEquality(expected, actual) {
+    if (expected !== actual) {
+        throw new NotMatchingError(expected, actual);
+    }
+}
+
+function errorToObject(e) {
+    'use strict';
+    var msg = e.toString();
+
+    // Opera 9.64 produces an non-standard string in toString().
+    if (msg.substr(0, 6) !== 'Error:') {
+        if (typeof e.message === 'string') {
+            msg = 'Error: ' + e.message;
+        }
+    }
+
+    return {
+        index: e.index,
+        lineNumber: e.lineNumber,
+        column: e.column,
+        message: msg
+    };
+}
+
+function sortedObject(o) {
+    var keys, result;
+    if (o === null) {
+        return o;
+    }
+    if (Array.isArray(o)) {
+        return o.map(sortedObject);
+    }
+    if (typeof o !== 'object') {
+        return o;
+    }
+    if (o instanceof RegExp) {
+        return o;
+    }
+    keys = Object.keys(o);
+    result = {
+        range: undefined,
+        loc: undefined
+    };
+    keys.forEach(function (key) {
+        if (o.hasOwnProperty(key)) {
+            result[key] = sortedObject(o[key]);
+        }
+    });
+    return result;
+}
+
+function hasAttachedComment(syntax) {
+    var key;
+    for (key in syntax) {
+        if (key === 'leadingComments' || key === 'trailingComments') {
+            return true;
+        }
+        if (typeof syntax[key] === 'object' && syntax[key] !== null) {
+            if (hasAttachedComment(syntax[key])) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function testParse(code, syntax) {
+    'use strict';
+    var expected, tree, actual, options, i, len;
+
+    options = {
+        comment: (typeof syntax.comments !== 'undefined'),
+        range: true,
+        loc: true,
+        tokens: (typeof syntax.tokens !== 'undefined'),
+        raw: true,
+        tolerant: (typeof syntax.errors !== 'undefined'),
+        source: null,
+        sourceType: syntax.sourceType
+    };
+
+    if (options.comment) {
+        options.attachComment = hasAttachedComment(syntax);
+    }
+
+    if (typeof syntax.tokens !== 'undefined') {
+        if (syntax.tokens.length > 0) {
+            options.range = (typeof syntax.tokens[0].range !== 'undefined');
+            options.loc = (typeof syntax.tokens[0].loc !== 'undefined');
+        }
+    }
+
+    if (typeof syntax.comments !== 'undefined') {
+        if (syntax.comments.length > 0) {
+            options.range = (typeof syntax.comments[0].range !== 'undefined');
+            options.loc = (typeof syntax.comments[0].loc !== 'undefined');
+        }
+    }
+
+    if (options.loc) {
+        options.source = syntax.loc.source;
+    }
+
+    syntax = sortedObject(syntax);
+    expected = JSON.stringify(syntax, null, 4);
+    try {
+        // Some variations of the options.
+        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType });
+        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType, range: true });
+        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType, loc: true });
+
+        tree = esprima.parse(code, options);
+
+        if (options.tolerant) {
+            for (i = 0, len = tree.errors.length; i < len; i += 1) {
+                tree.errors[i] = errorToObject(tree.errors[i]);
+            }
+        }
+        tree = sortedObject(tree);
+        actual = JSON.stringify(tree, null, 4);
+
+        // Only to ensure that there is no error when using string object.
+        esprima.parse(new String(code), options);
+
+    } catch (e) {
+        throw new NotMatchingError(expected, e.toString());
+    }
+
+    assertEquality(expected, actual);
+
+    function filter(key, value) {
+        return (key === 'loc' || key === 'range') ? undefined : value;
+    }
+
+    if (options.tolerant) {
+        return;
+    }
+
+    // Check again without any location info.
+    options.range = false;
+    options.loc = false;
+    syntax = sortedObject(syntax);
+    expected = JSON.stringify(syntax, filter, 4);
+    try {
+        tree = esprima.parse(code, options);
+
+        if (options.tolerant) {
+            for (i = 0, len = tree.errors.length; i < len; i += 1) {
+                tree.errors[i] = errorToObject(tree.errors[i]);
+            }
+        }
+        tree = sortedObject(tree);
+        actual = JSON.stringify(tree, filter, 4);
+    } catch (e) {
+        throw new NotMatchingError(expected, e.toString());
+    }
+
+    assertEquality(expected, actual);
+}
+
+function testTokenize(code, tokens) {
+    'use strict';
+    var options, expected, actual, tree;
+
+    options = {
+        comment: true,
+        tolerant: true,
+        loc: true,
+        range: true
+    };
+
+    expected = JSON.stringify(tokens, null, 4);
+
+    try {
+        tree = esprima.tokenize(code, options);
+        actual = JSON.stringify(tree, null, 4);
+    } catch (e) {
+        throw new NotMatchingError(expected, e.toString());
+    }
+    if (expected !== actual) {
+        throw new NotMatchingError(expected, actual);
+    }
+}
+
+function testModule(code, exception) {
+    'use strict';
+    var i, options, expected, actual, err, handleInvalidRegexFlag, tokenize;
+
+    // Different parsing options should give the same error.
+    options = [
+        { sourceType: 'module' },
+        { sourceType: 'module', comment: true },
+        { sourceType: 'module', raw: true },
+        { sourceType: 'module', raw: true, comment: true }
+    ];
+
+    if (!exception.message) {
+        exception.message = 'Error: Line 1: ' + exception.description;
+    }
+    exception.description = exception.message.replace(/Error: Line [0-9]+: /, '');
+
+    expected = JSON.stringify(exception);
+
+    for (i = 0; i < options.length; i += 1) {
+
+        try {
+            esprima.parse(code, options[i]);
+        } catch (e) {
+            err = errorToObject(e);
+            err.description = e.description;
+            actual = JSON.stringify(err);
+        }
+
+        if (expected !== actual) {
+
+            // Compensate for old V8 which does not handle invalid flag.
+            if (exception.message.indexOf('Invalid regular expression') > 0) {
+                if (typeof actual === 'undefined' && !handleInvalidRegexFlag) {
+                    return;
+                }
+            }
+
+            throw new NotMatchingError(expected, actual);
+        }
+
+    }
+}
+
+function testError(code, exception) {
+    'use strict';
+    var i, options, expected, actual, err, handleInvalidRegexFlag, tokenize;
+
+    // Different parsing options should give the same error.
+    options = [
+        {},
+        { comment: true },
+        { raw: true },
+        { raw: true, comment: true }
+    ];
+
+    // If handleInvalidRegexFlag is true, an invalid flag in a regular expression
+    // will throw an exception. In some old version of V8, this is not the case
+    // and hence handleInvalidRegexFlag is false.
+    handleInvalidRegexFlag = false;
+    try {
+        'test'.match(new RegExp('[a-z]', 'x'));
+    } catch (e) {
+        handleInvalidRegexFlag = true;
+    }
+
+    exception.description = exception.message.replace(/Error: Line [0-9]+: /, '');
+
+    if (exception.tokenize) {
+        tokenize = true;
+        exception.tokenize = undefined;
+    }
+    expected = JSON.stringify(exception);
+
+    for (i = 0; i < options.length; i += 1) {
+
+        try {
+            if (tokenize) {
+                esprima.tokenize(code, options[i]);
+            } else {
+                esprima.parse(code, options[i]);
+            }
+        } catch (e) {
+            err = errorToObject(e);
+            err.description = e.description;
+            actual = JSON.stringify(err);
+        }
+
+        if (expected !== actual) {
+
+            // Compensate for old V8 which does not handle invalid flag.
+            if (exception.message.indexOf('Invalid regular expression') > 0) {
+                if (typeof actual === 'undefined' && !handleInvalidRegexFlag) {
+                    return;
+                }
+            }
+
+            throw new NotMatchingError(expected, actual);
+        }
+
+    }
+}
+
+function testAPI(code, expected) {
+    var result;
+    // API test.
+    expected = JSON.stringify(expected, null, 4);
+    result = eval(code);
+    result = JSON.stringify(result, null, 4);
+
+    assertEquality(expected, result);
+}
+
+function evaluateTestCase(testCase) {
+    var code = testCase.case || testCase.source || "";
+
+    if (testCase.hasOwnProperty('module')) {
+        testModule(testCase.case, testCase.module);
+    } else if (testCase.hasOwnProperty('tree')) {
+        testParse(code, testCase.tree);
+    } else if (testCase.hasOwnProperty('tokens')) {
+        testTokenize(testCase.case, testCase.tokens);
+    } else if (testCase.hasOwnProperty('failure')) {
+        testError(code, testCase.failure);
+    } else if (testCase.hasOwnProperty('result')) {
+        testAPI(testCase.run, testCase.result);
+    }
+}
+
+
+window.evaluateTestCase = evaluateTestCase;

--- a/tools/generate-fixtures.js
+++ b/tools/generate-fixtures.js
@@ -50,7 +50,7 @@ function renderFixturesFile(ext, stringify) {
         var content = "";
         content += "var fixtures_" + ext + " = {};\n";
         content += fixtures;
-        content += "module.exports = fixtures_" + ext;
+        content += "\nif(typeof module !== 'undefined'){ module.exports = fixtures_" + ext + "}";
 
         return content;
     }


### PR DESCRIPTION
This PR adds a karma `test-runner` and a `browser-tests.js` helper.

#### Karma Runner
+ designed to help devs 
+ runs in chrome and watches for changes
+ does not have coverage (I'm thinking that will be the next todo item)

#### Browser Tests
+ copies over the unit-test helpers (testX errorToObject etc, unifying code will probably be a todo item)
+ uses mocha (I think the reporter w/ describe/it is a nice win)
+ uses chai (we're not using a lot of chai, so i think i'll remove it for the time being)
+ has a custom provider (there's a lot of code there that will be cleaned up)

#### What about the 40 failing tests? 
+ 1 was the invalid-yield
+ 1 was source-element being empty
+ 30 were the `var source ="something"` tests. turns out that we need to eval and get the source (facepalm)


#### Next Steps
+ Add coverage
+ Unify code
+ remove generate-testCase.js from unit-tests
+ syntax highlight source in test runner
+ Add additional runner debugger helpers. This is a catch all of half-baked ideas i have for helping a newcomer step through a test case and keep track of the AST and tokens as it's built out... 
 

----

![](https://www.dropbox.com/s/ee9r69ffnal9abo/Screenshot%202015-07-22%2010.52.27.jpg?dl=1)


[Full Runner Preview](https://www.dropbox.com/s/9jaee0teokphp2i/esprima-tests.png?dl=1) 