### PR TITLE
Reformat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,84 +1,79 @@
 {
-    "name": "esprima",
-    "description": "ECMAScript parsing infrastructure for multipurpose analysis",
-    "homepage": "http://esprima.org",
-    "main": "esprima.js",
-    "bin": {
-        "esparse": "./bin/esparse.js",
-        "esvalidate": "./bin/esvalidate.js"
-    },
-    "version": "2.4.0",
-    "files": [
-        "bin",
-        "unit-tests.js",
-        "esprima.js"
-    ],
-    "engines": {
-        "node": ">=0.10.0"
-    },
-    "author": {
-        "name": "Ariya Hidayat",
-        "email": "ariya.hidayat@gmail.com"
-    },
-    "maintainers": [{
-        "name": "Ariya Hidayat",
-        "email": "ariya.hidayat@gmail.com",
-        "web": "http://ariya.ofilabs.com"
-    }],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/jquery/esprima.git"
-    },
-    "bugs": {
-        "url": "https://github.com/jquery/esprima/issues"
-    },
-    "license": "BSD-2-Clause",
-    "devDependencies": {
-        "coveralls": "~2.11.2",
-        "escomplex-js": "1.2.0",
-        "eslint": "~0.23.0",
-        "glob": "^5.0.14",
-        "istanbul": "~0.3.16",
-        "jscs": "~1.13.1",
-        "json-diff": "~0.3.1",
-        "node-tick-processor": "~0.0.2",
-        "regenerate": "~0.6.2",
-        "unicode-7.0.0": "~0.1.5"
-    },
-    "keywords": [
-        "ast",
-        "ecmascript",
-        "javascript",
-        "parser",
-        "syntax"
-    ],
-    "scripts": {
-
-        "check-version": "node test/check-version.js",
-        "jscs": "jscs esprima.js && jscs test/*.js",
-        "eslint": "node node_modules/eslint/bin/eslint.js -c .lintrc esprima.js",
-        "complexity": "node test/check-complexity.js",
-        "static-analysis": "npm run check-version && npm run jscs && npm run eslint && npm run complexity",
-
-        "unit-tests": "node test/unit-tests.js",
-        "regression-tests": "node test/regression-tests.js",
-        "tests": "npm run unit-tests && npm run regression-tests",
-
-        "analyze-coverage": "istanbul cover test/unit-tests.js",
-        "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
-        "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
-
-        "test": "npm run tests && npm run static-analysis && npm run dynamic-analysis",
-
-        "profile": "node --prof test/profile.js && mv isolate*.log v8.log && node-tick-processor",
-        "benchmark": "node test/benchmarks.js",
-        "benchmark-quick": "node test/benchmarks.js quick",
-
-        "coveralls": "coveralls < ./coverage/lcov.info",
-        "downstream": "node test/downstream.js",
-        "travis": "npm test && npm run coveralls && npm run downstream",
-
-        "generate-regex": "node tools/generate-identifier-regex.js",
-        "generate-fixtures": "node tools/generate-fixtures.js"
+  "name": "esprima",
+  "description": "ECMAScript parsing infrastructure for multipurpose analysis",
+  "homepage": "http://esprima.org",
+  "main": "esprima.js",
+  "bin": {
+    "esparse": "./bin/esparse.js",
+    "esvalidate": "./bin/esvalidate.js"
+  },
+  "version": "2.4.0",
+  "files": [
+    "bin",
+    "unit-tests.js",
+    "esprima.js"
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "author": {
+    "name": "Ariya Hidayat",
+    "email": "ariya.hidayat@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "Ariya Hidayat",
+      "email": "ariya.hidayat@gmail.com",
+      "web": "http://ariya.ofilabs.com"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jquery/esprima.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jquery/esprima/issues"
+  },
+  "license": "BSD-2-Clause",
+  "devDependencies": {
+    "coveralls": "~2.11.2",
+    "escomplex-js": "1.2.0",
+    "eslint": "~0.23.0",
+    "glob": "^5.0.14",
+    "istanbul": "~0.3.16",
+    "jscs": "~1.13.1",
+    "json-diff": "~0.3.1",
+    "node-tick-processor": "~0.0.2",
+    "regenerate": "~0.6.2",
+    "unicode-7.0.0": "~0.1.5"
+  },
+  "keywords": [
+    "ast",
+    "ecmascript",
+    "javascript",
+    "parser",
+    "syntax"
+  ],
+  "scripts": {
+    "check-version": "node test/check-version.js",
+    "jscs": "jscs esprima.js && jscs test/*.js",
+    "eslint": "node node_modules/eslint/bin/eslint.js -c .lintrc esprima.js",
+    "complexity": "node test/check-complexity.js",
+    "static-analysis": "npm run check-version && npm run jscs && npm run eslint && npm run complexity",
+    "unit-tests": "node test/unit-tests.js",
+    "regression-tests": "node test/regression-tests.js",
+    "tests": "npm run unit-tests && npm run regression-tests",
+    "analyze-coverage": "istanbul cover test/unit-tests.js",
+    "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
+    "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
+    "test": "npm run tests && npm run static-analysis && npm run dynamic-analysis",
+    "profile": "node --prof test/profile.js && mv isolate*.log v8.log && node-tick-processor",
+    "benchmark": "node test/benchmarks.js",
+    "benchmark-quick": "node test/benchmarks.js quick",
+    "coveralls": "coveralls < ./coverage/lcov.info",
+    "downstream": "node test/downstream.js",
+    "travis": "npm test && npm run coveralls && npm run downstream",
+    "generate-regex": "node tools/generate-identifier-regex.js",
+    "generate-fixtures": "node tools/generate-fixtures.js"
+  }
 }


### PR DESCRIPTION
I apologize in advance for this annoying PR. When `npm install` is run, it reformats the package.json file with this [line](https://github.com/npm/npm/blob/36a412d0eb065cdd1e916f6b001c098ff5c7efc3/lib/install.js#L388). There's been a long [thread](https://github.com/npm/npm/pull/3062) over many years and the isaacs does not want to change this. 

I realize that everything else in the project is formatted with 4 spaces, but it *is* frustrating when the npm tool causes nasty diffs. This is not a big deal, but thought I'd raise it nonetheless. I didn't create a backing issue, because it seemed too small. happy to do that if it'd help or add another issue ref. 