### PR TITLE
Cleanup Test Runners

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
       'node_modules/lodash/index.js',
       'test/dist/fixtures_js.js',
       'test/dist/fixtures_json.js',
+      'test/utils/create-testcases.js',
       'test/utils/evaluate-testcase.js',
       'test/browser-tests.js',
     ],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "unit-tests": "node test/unit-tests.js",
     "grammar-tests": "node test/grammar-tests.js",
     "regression-tests": "node test/regression-tests.js",
-    "tests": "npm run unit-tests && npm run grammar-tests && npm run regression-tests",
+    "tests": "npm run generate-fixtures && npm run unit-tests && npm run grammar-tests && npm run regression-tests",
     "generate-fixtures": "node tools/generate-fixtures.js",
     "browser-tests": "npm run generate-fixtures && karma start --single-run",
     "analyze-coverage": "istanbul cover test/unit-tests.js",

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -24,7 +24,8 @@
 
 'use strict';
 
-var esprima = require('../esprima'),
+var evaluateTestCase = require('./utils/evaluate-testcase'),
+    createTestCases = require('./utils/create-testcases'),
     fs = require('fs'),
     diff = require('json-diff').diffString,
     total = 0,
@@ -33,399 +34,35 @@ var esprima = require('../esprima'),
     cases = {},
     context = {source: '', result: null},
     tick = new Date(),
-    expected,
     testCase,
     header;
 
-function NotMatchingError(expected, actual) {
-    Error.call(this, 'Expected ');
-    this.expected = expected;
-    this.actual = actual;
-}
-NotMatchingError.prototype = new Error();
-
-function errorToObject(e) {
-    'use strict';
-    var msg = e.toString();
-
-    // Opera 9.64 produces an non-standard string in toString().
-    if (msg.substr(0, 6) !== 'Error:') {
-        if (typeof e.message === 'string') {
-            msg = 'Error: ' + e.message;
-        }
-    }
-
-    return {
-        index: e.index,
-        lineNumber: e.lineNumber,
-        column: e.column,
-        message: msg
-    };
-}
-
-function sortedObject(o) {
-    var keys, result;
-    if (o === null) {
-        return o;
-    }
-    if (Array.isArray(o)) {
-        return o.map(sortedObject);
-    }
-    if (typeof o !== 'object') {
-        return o;
-    }
-    if (o instanceof RegExp) {
-        return o;
-    }
-    keys = Object.keys(o);
-    result = {
-        range: undefined,
-        loc: undefined
-    };
-    keys.forEach(function (key) {
-        if (o.hasOwnProperty(key)) {
-            result[key] = sortedObject(o[key]);
-        }
-    });
-    return result;
-}
-
-function hasAttachedComment(syntax) {
-    var key;
-    for (key in syntax) {
-        if (key === 'leadingComments' || key === 'trailingComments') {
-            return true;
-        }
-        if (typeof syntax[key] === 'object' && syntax[key] !== null) {
-            if (hasAttachedComment(syntax[key])) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-function testParse(esprima, code, syntax) {
-    'use strict';
-    var expected, tree, actual, options, i, len;
-
-    options = {
-        comment: (typeof syntax.comments !== 'undefined'),
-        range: true,
-        loc: true,
-        tokens: (typeof syntax.tokens !== 'undefined'),
-        raw: true,
-        tolerant: (typeof syntax.errors !== 'undefined'),
-        source: null,
-        sourceType: syntax.sourceType
-    };
-
-    if (options.comment) {
-        options.attachComment = hasAttachedComment(syntax);
-    }
-
-    if (typeof syntax.tokens !== 'undefined') {
-        if (syntax.tokens.length > 0) {
-            options.range = (typeof syntax.tokens[0].range !== 'undefined');
-            options.loc = (typeof syntax.tokens[0].loc !== 'undefined');
-        }
-    }
-
-    if (typeof syntax.comments !== 'undefined') {
-        if (syntax.comments.length > 0) {
-            options.range = (typeof syntax.comments[0].range !== 'undefined');
-            options.loc = (typeof syntax.comments[0].loc !== 'undefined');
-        }
-    }
-
-    if (options.loc) {
-        options.source = syntax.loc.source;
-    }
-
-    syntax = sortedObject(syntax);
-    expected = JSON.stringify(syntax, null, 4);
-    try {
-        // Some variations of the options.
-        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType });
-        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType, range: true });
-        tree = esprima.parse(code, { tolerant: options.tolerant, sourceType: options.sourceType, loc: true });
-
-        tree = esprima.parse(code, options);
-
-        if (options.tolerant) {
-            for (i = 0, len = tree.errors.length; i < len; i += 1) {
-                tree.errors[i] = errorToObject(tree.errors[i]);
-            }
-        }
-        tree = sortedObject(tree);
-        actual = JSON.stringify(tree, null, 4);
-
-        // Only to ensure that there is no error when using string object.
-        esprima.parse(new String(code), options);
-
-    } catch (e) {
-        throw new NotMatchingError(expected, e.toString());
-    }
-    if (expected !== actual) {
-        throw new NotMatchingError(expected, actual);
-    }
-
-    function filter(key, value) {
-        return (key === 'loc' || key === 'range') ? undefined : value;
-    }
-
-    if (options.tolerant) {
-        return;
-    }
-
-
-    // Check again without any location info.
-    options.range = false;
-    options.loc = false;
-    syntax = sortedObject(syntax);
-    expected = JSON.stringify(syntax, filter, 4);
-    try {
-        tree = esprima.parse(code, options);
-
-        if (options.tolerant) {
-            for (i = 0, len = tree.errors.length; i < len; i += 1) {
-                tree.errors[i] = errorToObject(tree.errors[i]);
-            }
-        }
-        tree = sortedObject(tree);
-        actual = JSON.stringify(tree, filter, 4);
-    } catch (e) {
-        throw new NotMatchingError(expected, e.toString());
-    }
-    if (expected !== actual) {
-        throw new NotMatchingError(expected, actual);
-    }
-}
-
-function testTokenize(esprima, code, tokens) {
-    'use strict';
-    var options, expected, actual, tree;
-
-    options = {
-        comment: true,
-        tolerant: true,
-        loc: true,
-        range: true
-    };
-
-    expected = JSON.stringify(tokens, null, 4);
-
-    try {
-        tree = esprima.tokenize(code, options);
-        actual = JSON.stringify(tree, null, 4);
-    } catch (e) {
-        throw new NotMatchingError(expected, e.toString());
-    }
-    if (expected !== actual) {
-        throw new NotMatchingError(expected, actual);
-    }
-}
-
-
-function testModule(esprima, code, exception) {
-    'use strict';
-    var i, options, expected, actual, err, handleInvalidRegexFlag, tokenize;
-
-    // Different parsing options should give the same error.
-    options = [
-        { sourceType: 'module' },
-        { sourceType: 'module', comment: true },
-        { sourceType: 'module', raw: true },
-        { sourceType: 'module', raw: true, comment: true }
-    ];
-
-    if (!exception.message) {
-        exception.message = 'Error: Line 1: ' + exception.description;
-    }
-    exception.description = exception.message.replace(/Error: Line [0-9]+: /, '');
-
-    expected = JSON.stringify(exception);
-
-    for (i = 0; i < options.length; i += 1) {
-
-        try {
-            esprima.parse(code, options[i]);
-        } catch (e) {
-            err = errorToObject(e);
-            err.description = e.description;
-            actual = JSON.stringify(err);
-        }
-
-        if (expected !== actual) {
-
-            // Compensate for old V8 which does not handle invalid flag.
-            if (exception.message.indexOf('Invalid regular expression') > 0) {
-                if (typeof actual === 'undefined' && !handleInvalidRegexFlag) {
-                    return;
-                }
-            }
-
-            throw new NotMatchingError(expected, actual);
-        }
-
-    }
-}
-
-function testError(esprima, code, exception) {
-    'use strict';
-    var i, options, expected, actual, err, handleInvalidRegexFlag, tokenize;
-
-    // Different parsing options should give the same error.
-    options = [
-        {},
-        { comment: true },
-        { raw: true },
-        { raw: true, comment: true }
-    ];
-
-    // If handleInvalidRegexFlag is true, an invalid flag in a regular expression
-    // will throw an exception. In some old version of V8, this is not the case
-    // and hence handleInvalidRegexFlag is false.
-    handleInvalidRegexFlag = false;
-    try {
-        'test'.match(new RegExp('[a-z]', 'x'));
-    } catch (e) {
-        handleInvalidRegexFlag = true;
-    }
-
-    exception.description = exception.message.replace(/Error: Line [0-9]+: /, '');
-
-    if (exception.tokenize) {
-        tokenize = true;
-        exception.tokenize = undefined;
-    }
-    expected = JSON.stringify(exception);
-
-    for (i = 0; i < options.length; i += 1) {
-
-        try {
-            if (tokenize) {
-                esprima.tokenize(code, options[i]);
-            } else {
-                esprima.parse(code, options[i]);
-            }
-        } catch (e) {
-            err = errorToObject(e);
-            err.description = e.description;
-            actual = JSON.stringify(err);
-        }
-
-        if (expected !== actual) {
-
-            // Compensate for old V8 which does not handle invalid flag.
-            if (exception.message.indexOf('Invalid regular expression') > 0) {
-                if (typeof actual === 'undefined' && !handleInvalidRegexFlag) {
-                    return;
-                }
-            }
-
-            throw new NotMatchingError(expected, actual);
-        }
-
-    }
-}
-
-function testAPI(esprima, code, expected) {
-    var result;
-    // API test.
-    expected = JSON.stringify(expected, null, 4);
-    try {
-        result = eval(code);
-        result = JSON.stringify(result, null, 4);
-    } catch (e) {
-        throw new NotMatchingError(expected, e.toString());
-    }
-    if (expected !== result) {
-        throw new NotMatchingError(expected, result);
-    }
-}
-
-function generateTestCase(esprima, testCase) {
-    var tree, fileName = testCase.key + ".tree.json";
-    try {
-        tree = esprima.parse(testCase.case, {loc: true, range: true});
-        tree = JSON.stringify(tree, null, 4);
-    } catch (e) {
-        if (typeof e.index === 'undefined') {
-            console.error("Failed to generate test result.");
-            throw e;
-        }
-        tree = errorToObject(e);
-        tree.description = e.description;
-        tree = JSON.stringify(tree);
-        fileName = testCase.key + ".failure.json";
-    }
-    require('fs').writeFileSync(fileName, tree);
-    console.error("Done.");
-}
-
-
-function enumerateFixtures(root) {
-    var dirs = fs.readdirSync(root), key, kind,
-        kinds = ['case', 'source', 'module', 'run', 'tree', 'tokens', 'failure', 'result'],
-        suffices = ['js', 'js', 'json', 'js', 'json', 'json', 'json', 'json'];
-
-    dirs.forEach(function (item) {
-        var i, suffix;
-        if (fs.statSync(root + '/' + item).isDirectory()) {
-            enumerateFixtures(root + '/' + item);
-        } else {
-            kind = 'case';
-            key = item.slice(0, -3);
-            for (i = 1; i < kinds.length; i++) {
-                suffix = '.' + kinds[i] + '.' + suffices[i];
-                if (item.slice(-suffix.length) === suffix) {
-                    key = item.slice(0, -suffix.length);
-                    kind = kinds[i];
-                }
-            }
-            key = root + '/' + key;
-            if (!cases[key]) {
-                total++;
-                cases[key] = { key: key };
-            }
-            cases[key][kind] = fs.readFileSync(root + '/' + item, 'utf-8');
-        }
-    });
-}
-
-enumerateFixtures(__dirname + '/fixtures');
+cases = createTestCases();
+total = Object.keys(cases).length;
 
 Object.keys(cases).forEach(function (key) {
-    if (cases.hasOwnProperty(key)) {
-        testCase = cases[key];
+    testCase = cases[key];
 
-        if (testCase.hasOwnProperty('source')) {
-            testCase.case = eval(testCase.source + ';source');
-        }
+    if (testCase.hasOwnProperty('module')
+        || testCase.hasOwnProperty('tree')
+        || testCase.hasOwnProperty('tokens')
+        || testCase.hasOwnProperty('failure')
+        || testCase.hasOwnProperty('result')) {
 
         try {
-            if (testCase.hasOwnProperty('module')) {
-                testModule(esprima, testCase.case, JSON.parse(testCase.module));
-            } else if (testCase.hasOwnProperty('tree')) {
-                testParse(esprima, testCase.case, JSON.parse(testCase.tree));
-            } else if (testCase.hasOwnProperty('tokens')) {
-                testTokenize(esprima, testCase.case, JSON.parse(testCase.tokens));
-            } else if (testCase.hasOwnProperty('failure')) {
-                testError(esprima, testCase.case, JSON.parse(testCase.failure));
-            } else if (testCase.hasOwnProperty('result')) {
-                testAPI(esprima, testCase.run, JSON.parse(testCase.result));
-            } else {
-                console.error('Incomplete test case:' + testCase.key + '. Generating test result...');
-                generateTestCase(esprima, testCase);
-            }
+            evaluateTestCase(testCase);
         } catch (e) {
             if (!e.expected) {
                 throw e;
             }
+
             e.source = testCase.case || testCase.key;
             failures.push(e);
         }
+
+    } else {
+        console.error('Incomplete test case:' + testCase.key + '. Generating test result...');
+        generateTestCase();
     }
 });
 
@@ -436,22 +73,22 @@ header = total + ' tests. ' + failures.length + ' failures. ' + tick + ' ms';
 if (failures.length) {
     console.error(header);
     failures.forEach(function (failure) {
-        try {
-            var expectedObject = JSON.parse(failure.expected),
-                actualObject = JSON.parse(failure.actual);
+       try {
+           var expectedObject = JSON.parse(failure.expected),
+               actualObject = JSON.parse(failure.actual);
 
-            console.error(failure.source + ': Expected\n    ' +
-                failure.expected.split('\n').join('\n    ') +
-                '\nto match\n    ' + failure.actual + '\nDiff:\n' +
-                diff(expectedObject, actualObject));
-        } catch (ex) {
-            console.error(failure.source + ': Expected\n    ' +
-                failure.expected.split('\n').join('\n    ') +
-                '\nto match\n    ' + failure.actual);
-        }
-    });
+           console.error(failure.source + ': Expected\n    ' +
+               failure.expected.split('\n').join('\n    ') +
+               '\nto match\n    ' + failure.actual + '\nDiff:\n' +
+               diff(expectedObject, actualObject));
+       } catch (ex) {
+           console.error(failure.source + ': Expected\n    ' +
+               failure.expected.split('\n').join('\n    ') +
+               '\nto match\n    ' + failure.actual);
+       }
+   });
 } else {
     console.log(header);
 }
-process.exit(failures.length === 0 ? 0 : 1);
 
+process.exit(failures.length === 0 ? 0 : 1);

--- a/test/utils/create-testcases.js
+++ b/test/utils/create-testcases.js
@@ -1,0 +1,124 @@
+/*
+  Copyright (c) jQuery Foundation, Inc. and Contributors, All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+'use strict';
+
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory(
+            require('lodash'),
+            require('../dist/fixtures_js'),
+            require('../dist/fixtures_json')
+        );
+    } else {
+        root.createTestCases = factory(_, window.fixtures_js, window.fixtures_json);
+    }
+}(this, function (_, jsFixtures, jsonFixtures) {
+
+    var cases;
+
+    function addCase(key, kind, item) {
+        if (!cases[key]) {
+            cases[key] = { key: key };
+        }
+
+        cases[key][kind] = item;
+    }
+
+    function addJsonFixture(value, filePath) {
+        /**
+         * Determines which type of test it is based on the filepath
+         */
+        function getType() {
+            return _(['module', 'tree', 'tokens', 'failure', 'result']).find(function (type) {
+                var suffix = '.' + type;
+                return (filePath.slice(-suffix.length) === suffix);
+            });
+        }
+
+        function getKey() {
+            return filePath.slice(0, -getType().length - 1)
+        }
+
+        function getValue() {
+            return value;
+        }
+
+        return addCase(getKey(), getType(), getValue());
+    }
+
+    function addJSFixture(value, filePath) {
+        /**
+         * checks to see if filepath is a run or source type.
+         */
+        function checkType(type) {
+            var suffix = '.' + type;
+            return filePath.slice(-suffix.length) === suffix
+        }
+
+        /**
+         * builds a case key by stripping away the type
+         */
+        function getKey(type) {
+            return filePath.slice(0, -type.length - 1)
+        }
+
+        /**
+         * returns the js test case.
+         * In the case of source tests, the input needs to be evaluated.
+         */
+        function getValue(value, shouldEval) {
+            var source, newValue;
+
+            if (shouldEval) {
+                // return source from the eval
+                newValue = eval(value + ';source');
+            } else {
+                newValue = value;
+            }
+
+            return newValue;
+        }
+
+        if (checkType('run')) {
+            return addCase(getKey('run'), 'run', getValue(value));
+        }
+
+        if (checkType('source')) {
+            return addCase(getKey('source'), 'source', getValue(value, true));
+        }
+
+        return addCase(filePath, 'case', getValue(value));
+    }
+
+    /**
+     * Reads jsFixtures and jsonFixtures into cases dictionary
+     */
+    return function () {
+        cases = {};
+        _.each(jsFixtures, addJSFixture);
+        _.each(jsonFixtures, addJsonFixture);
+        return cases;
+    }
+}));


### PR DESCRIPTION
Refs #1258
#### Overview
This is a collection of cleanup items that were related
to creating the Browser Test Runner in isolation, and
now unifying the codebase.

#### The test runners share two utilities:

1. createTestCases
2. evaluateTestCase

#### What is different about the two test runners?
+ The browser test runner has a nested mocha reporter
+ The node test runner has a simple reporter, diffed outputs, and can
generate test cases

#### This is a really big patch, what's actually changed?

+ Not much. I recommend looking at the diff with `?w=1` because evaluate-testcase looks like it changed but the UMD wrapper caused indentation
+ `createTestCases` was extracted from `browser-tests` 
+ `enumerateFixtures` was deleted in `unit-tests.js`
+ `evaluateTestCase` was required in `unit-tests.js` and all of the shared code was dropped
+ With all that said, I apologize that this PR is a lot of code to follow. 