### PR TITLE
Corrects spelling of "ESTree" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with the help of [many contributors](https://github.com/jquery/esprima/contribut
 ### Features
 
 - Full support for ECMAScript 6 ([ECMA-262](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
-- Sensible [syntax tree format](https://github.com/estree/estree/blob/master/spec.md) as standardized by [EStree project](https://github.com/estree/estree)
+- Sensible [syntax tree format](https://github.com/estree/estree/blob/master/spec.md) as standardized by [ESTree project](https://github.com/estree/estree)
 - Optional tracking of syntax node location (index-based and line-column)
 - Heavily tested (~1200 [unit tests](https://github.com/jquery/esprima/tree/master/test/fixtures) with [full code coverage](https://travis-ci.org/jquery/esprima))
 


### PR DESCRIPTION
Just a tiny typo.