### PR TITLE
Fix generateTestCase

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
       'node_modules/lodash/index.js',
       'test/dist/fixtures_js.js',
       'test/dist/fixtures_json.js',
+      'test/utils/error-to-object.js',
       'test/utils/create-testcases.js',
       'test/utils/evaluate-testcase.js',
       'test/browser-tests.js',

--- a/test/utils/error-to-object.js
+++ b/test/utils/error-to-object.js
@@ -1,0 +1,46 @@
+/*
+  Copyright (c) jQuery Foundation, Inc. and Contributors, All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+'use strict';
+
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.errorToObject = factory();
+    }
+}(this, function() {
+
+  return function (e) {
+      'use strict';
+      var msg = e.toString();
+
+      return {
+          index: e.index,
+          lineNumber: e.lineNumber,
+          column: e.column,
+          message: msg
+      };
+  }
+}));

--- a/test/utils/evaluate-testcase.js
+++ b/test/utils/evaluate-testcase.js
@@ -26,11 +26,14 @@
 
 (function (root, factory) {
     if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('../../esprima'));
+        module.exports = factory(
+            require('../../esprima'),
+            require('./error-to-object')
+        );
     } else {
-        root.evaluateTestCase = factory(esprima);
+        root.evaluateTestCase = factory(esprima, errorToObject);
     }
-}(this, function (esprima) {
+}(this, function (esprima, errorToObject) {
     function NotMatchingError(expected, actual) {
         Error.call(this, 'Expected ');
         this.expected = expected;
@@ -42,25 +45,6 @@
         if (expected !== actual) {
             throw new NotMatchingError(expected, actual);
         }
-    }
-
-    function errorToObject(e) {
-        'use strict';
-        var msg = e.toString();
-
-        // Opera 9.64 produces an non-standard string in toString().
-        if (msg.substr(0, 6) !== 'Error:') {
-            if (typeof e.message === 'string') {
-                msg = 'Error: ' + e.message;
-            }
-        }
-
-        return {
-            index: e.index,
-            lineNumber: e.lineNumber,
-            column: e.column,
-            message: msg
-        };
     }
 
     function sortedObject(o) {


### PR DESCRIPTION
Refs #1258

When the test-runner logic was consolidated, the generateTestCase function was accidentally dropped. This re-adds the function and modularizes `errorToObject` which is shared between generateTestCase and evaluateTestCase.

Note: istanbul is throwing an error, which i still have to investigate.