### PR TITLE
Normalize regex testing when using the new ES6 regex flags.

### DIFF
--- a/test/utils/evaluate-testcase.js
+++ b/test/utils/evaluate-testcase.js
@@ -69,6 +69,13 @@
         keys.forEach(function (key) {
             if (o.hasOwnProperty(key)) {
                 result[key] = sortedObject(o[key]);
+
+                // Nullify regex value for ES6 regex flags
+                if (key === 'value' && o.hasOwnProperty('regex')) {
+                    if (o.regex.flags.match(/[uy]/)) {
+                        result[key] = null;
+                    }
+                }
             }
         });
         return result;


### PR DESCRIPTION
On an environment that already supports the new ES6 regex flags,
the regex value won't be null. This causes the test to be mistakenly
marked as a failure since the baseline has the null value.

To workaround this, ensure that regex value is always null when using
the new ES6 regex flags. Other comparisons will still happen to ensure
that the regex is handled properly.

Fixes #1271.