### PR TITLE
Fix Mocha browser runner

### DIFF
--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -59,6 +59,26 @@ function browserRunner(cases) {
         });
     }
 
+    /**
+     * builds a test case name to show in the mocha reporter
+     */
+    function testCaseName(testCase) {
+        var source, testCaseCase;
+
+        source = testCase.source || '';
+        testCaseCase = testCase.case || '';
+
+        // don't include the source in the name if it cannot
+        // be encoded as a URI component.
+        try {
+            encodeURIComponent(source);
+        } catch (e) {
+            source = ''
+        }
+
+        return testCase.key + " - " + source  + testCaseCase;
+    }
+
     function describeTests(tree, path) {
         var tests, testDirectory;
 
@@ -70,13 +90,7 @@ function browserRunner(cases) {
             })
 
             _.each(testCases, function (testCase) {
-                var source, testCaseCase, name;
-
-                source = testCase.source || '';
-                testCaseCase = testCase.case || '';
-                name = testCase.key + " - " + source  + testCaseCase;
-
-                it(name, function () {
+                it(testCaseName(testCase), function () {
                     evaluateTestCase(testCase);
                 });
             });


### PR DESCRIPTION
Refs #1278

Mocha fails when it encounters test names that are not URI encodable.
We now check to see if the source is encodabable before we add it to the
test name.