### PR TITLE
Delegate additional stress tests to Codeship.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "benchmark-quick": "node test/benchmarks.js quick",
     "codecov" : "istanbul report cobertura && codecov < ./coverage/cobertura-coverage.xml",
     "downstream": "node test/downstream.js",
-    "travis": "npm test && npm run codecov && npm run downstream",
+    "travis": "npm test",
+    "codeship": "npm test && npm run codecov && npm run downstream",
     "appveyor": "npm run tests && npm run browser-tests && npm run dynamic-analysis",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }


### PR DESCRIPTION
Codeship CI will run in parallel to verify and post the code coverage
information, as well as to run the downstream tests.

Fixes #1293.