### PR TITLE
Run the tests on Circle CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,3 @@ node_js:
   - iojs
   - "0.12"
   - "0.10"
-env:
-  - NO_WATCH_TESTS=1

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  node:
+    version:
+      0.12.0
+  environment:
+    NO_WATCH_TESTS: 1
+
+dependencies:
+  pre:
+    - node --version
+    - npm --version
+    - npm install
+
+test:
+  override:
+    - npm run circleci

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "benchmark-quick": "node test/benchmarks.js quick",
     "codecov" : "istanbul report cobertura && codecov < ./coverage/cobertura-coverage.xml",
     "downstream": "node test/downstream.js",
-    "travis": "npm test && npm run codecov && npm run downstream",
+    "travis": "npm test",
+    "circleci": "npm test && npm run codecov && npm run downstream",
     "appveyor": "npm run tests && npm run browser-tests && npm run dynamic-analysis",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }


### PR DESCRIPTION
Delegate additional stress tests to Circle CI.
    
Circle CI will run in parallel to verify and post the code coverage information, as well as to run the downstream tests.
    
Fixes #1293.