### PR TITLE
Downstream test: no futher need for globally installed Grunt.

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -49,7 +49,6 @@ function test_project(project, repo) {
 
     console.log();
     execute('npm install');
-    execute('npm install -g grunt-cli');
 
     console.log();
     console.log('Replacing esprima.js with a fresh one...');


### PR DESCRIPTION
This was needed for jsfmt, but it's not necessary anymore:
https://github.com/rdio/jsfmt/pull/163

Refs #1023