### PR TITLE
Fix nonsensical argument passing.

### DIFF
--- a/esprima.js
+++ b/esprima.js
@@ -2681,7 +2681,7 @@
                     restNode = new Node();
                     lex();
                     params.push(lookahead);
-                    rest = parseVariableIdentifier(params, kind);
+                    rest = parseVariableIdentifier(kind);
                     elements.push(restNode.finishRestElement(rest));
                     break;
                 } else {
@@ -2717,7 +2717,7 @@
                 return node.finishProperty('init', key, false, key, false, true);
             }
         } else {
-            key = parseObjectPropertyKey(params, kind);
+            key = parseObjectPropertyKey();
         }
         expect(':');
         init = parsePatternWithDefault(params, kind);


### PR DESCRIPTION
This was a mistake in the previous commit 3cf4d0b8, as
parseVariableIdentifier and parseObjectPropertyKey expect a different
number of arguments.

Refs #1098.