### PR TITLE
CircleCI test: increase the timeout from the default 10 mins (600 s).

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,5 @@ dependencies:
 
 test:
   override:
-    - npm run circleci
+    - npm run circleci:
+        timeout: 1200  # 20 minutes


### PR DESCRIPTION
Since CircleCI needs to carry out many stress tests, including
downstream project test, the default 10-minute running time is not
enough.

Refs #1293