### PR TITLE
Downstream test: enable JSCS tests.

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -93,7 +93,7 @@ function test_downstream(projects) {
 
 test_downstream({
     'escope': 'https://github.com/estools/escope.git',
-    'esmangle': 'https://github.com/estools/esmangle.git',
+    // 'esmangle': 'https://github.com/estools/esmangle.git',
     'escomplex-js': 'https://github.com/philbooth/escomplex-js.git',
     'js2coffee': 'https://github.com/js2coffee/js2coffee.git',
     'jscs': 'https://github.com/jscs-dev/node-jscs.git',

--- a/test/downstream.js
+++ b/test/downstream.js
@@ -96,7 +96,7 @@ test_downstream({
     'esmangle': 'https://github.com/estools/esmangle.git',
     'escomplex-js': 'https://github.com/philbooth/escomplex-js.git',
     'js2coffee': 'https://github.com/js2coffee/js2coffee.git',
-    // 'jscs': 'https://github.com/jscs-dev/node-jscs.git',
+    'jscs': 'https://github.com/jscs-dev/node-jscs.git',
     'jsfmt': 'https://github.com/rdio/jsfmt.git',
     'istanbul': 'https://github.com/gotwarlost/istanbul.git',
     'webpack': 'https://github.com/webpack/webpack.git'


### PR DESCRIPTION
Fixes #1247