### PR TITLE
Rename `tests` target in package.json to `all-tests`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,13 +74,13 @@
     "unit-tests": "node test/unit-tests.js",
     "grammar-tests": "node test/grammar-tests.js",
     "regression-tests": "node test/regression-tests.js",
-    "tests": "npm run generate-fixtures && npm run unit-tests && npm run grammar-tests && npm run regression-tests",
+    "all-tests": "npm run generate-fixtures && npm run unit-tests && npm run grammar-tests && npm run regression-tests",
     "generate-fixtures": "node tools/generate-fixtures.js",
     "browser-tests": "npm run generate-fixtures && cd test && karma start --single-run",
     "analyze-coverage": "istanbul cover test/unit-tests.js",
     "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
     "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
-    "test": "npm run tests && npm run static-analysis && npm run dynamic-analysis",
+    "test": "npm run all-tests && npm run static-analysis && npm run dynamic-analysis",
     "profile": "node --prof test/profile.js && mv isolate*.log v8.log && node-tick-processor",
     "benchmark": "node test/benchmarks.js",
     "benchmark-quick": "node test/benchmarks.js quick",
@@ -88,7 +88,7 @@
     "downstream": "node test/downstream.js",
     "travis": "npm test",
     "circleci": "npm test && npm run codecov && npm run downstream",
-    "appveyor": "npm run tests && npm run browser-tests && npm run dynamic-analysis",
+    "appveyor": "npm run all-tests && npm run browser-tests && npm run dynamic-analysis",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }
 }


### PR DESCRIPTION
`tests` triggers a warning from npm:

  scripts['tests'] should probably be scripts['test']