### PR TITLE
Use Sauce Labs to run the test suite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-ie-launcher": "^0.2.0",
     "karma-mocha": "^0.2.0",
     "karma-safari-launcher": "^0.1.1",
+    "karma-sauce-launcher": "^0.2.14",
     "lodash": "^3.10.0",
     "mocha": "^2.2.5",
     "node-tick-processor": "~0.0.2",
@@ -77,6 +78,9 @@
     "all-tests": "npm run generate-fixtures && npm run unit-tests && npm run grammar-tests && npm run regression-tests",
     "generate-fixtures": "node tools/generate-fixtures.js",
     "browser-tests": "npm run generate-fixtures && cd test && karma start --single-run",
+    "saucelabs-evergreen": "cd test && karma start saucelabs-evergreen.conf.js",
+    "saucelabs-safari": "cd test && karma start saucelabs-safari.conf.js",
+    "saucelabs-ie": "cd test && karma start saucelabs-ie.conf.js",
     "analyze-coverage": "istanbul cover test/unit-tests.js",
     "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
     "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
@@ -89,6 +93,7 @@
     "travis": "npm test",
     "circleci": "npm test && npm run codecov && npm run downstream",
     "appveyor": "npm run all-tests && npm run browser-tests && npm run dynamic-analysis",
+    "droneio": "npm test && npm run saucelabs-evergreen && npm run saucelabs-ie && npm run saucelabs-safari",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }
 }

--- a/test/configure-sauce-labs.js
+++ b/test/configure-sauce-labs.js
@@ -1,0 +1,49 @@
+module.exports = function (config, name, launchers) {
+    'use strict';
+
+    config.set({
+        basePath: '..',
+        frameworks: [
+            'mocha'
+        ],
+
+        files: [
+            'esprima.js',
+            'node_modules/lodash/index.js',
+            'test/dist/fixtures_js.js',
+            'test/dist/fixtures_json.js',
+            'test/utils/error-to-object.js',
+            'test/utils/create-testcases.js',
+            'test/utils/evaluate-testcase.js',
+            'test/browser-tests.js'
+        ],
+
+        exclude: [],
+
+        client: {
+            mocha: {
+                reporter: 'html', // change Karma's debug.html to the mocha web reporter
+                ui: 'bdd'
+            }
+        },
+
+        logLevel: config.LOG_WARN, // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        reporters: ['saucelabs'],
+        port: 9876,
+        colors: true,
+        singleRun: true,
+        captureTimeout: 2 * 60 * 1000,
+        browserNoActivityTimeout: 3 * 60 * 1000,
+        browserDisconnectTimeout : 3 * 60 * 1000,
+        browserDisconnectTolerance : 2,
+
+        sauceLabs: {
+            testName: name,
+            build: process.env.GIT_COMMIT.substr(0, 10),
+            startConnect: false,
+            recordScreenshots: false
+        },
+        browsers: Object.keys(launchers),
+        customLaunchers: launchers
+    });
+}

--- a/test/saucelabs-evergreen.conf.js
+++ b/test/saucelabs-evergreen.conf.js
@@ -1,0 +1,33 @@
+var configureSauceLabs = require('./configure-sauce-labs.js');
+
+module.exports = function (config) {
+
+    configureSauceLabs(config, 'Evergreen browsers', {
+        Edge: {
+            base: 'SauceLabs',
+            browserName: 'microsoftedge',
+            platform: 'Windows 10'
+        },
+        Chrome: {
+            base: 'SauceLabs',
+            browserName: 'chrome',
+            platform: 'Linux'
+        },
+        Chrome_Mobile: {
+            base: 'SauceLabs',
+            browserName: 'android',
+            platform: 'Linux'
+        },
+        Firefox: {
+            base: 'SauceLabs',
+            browserName: 'firefox',
+            platform: 'Linux'
+        },
+        Safari: {
+            base: 'SauceLabs',
+            browserName: 'safari',
+            platform: 'OS X 10.11'
+        }
+    });
+
+}

--- a/test/saucelabs-ie.conf.js
+++ b/test/saucelabs-ie.conf.js
@@ -1,0 +1,26 @@
+var configureSauceLabs = require('./configure-sauce-labs.js');
+
+module.exports = function (config) {
+
+    configureSauceLabs(config, 'Internet Explorer browsers', {
+        IE_11: {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 7',
+            version: '11.0'
+        },
+        IE_10: {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 7',
+            version: '10.0'
+        },
+        IE_9: {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 7',
+            version: '9.0'
+        }
+    });
+
+}

--- a/test/saucelabs-safari.conf.js
+++ b/test/saucelabs-safari.conf.js
@@ -1,0 +1,32 @@
+var configureSauceLabs = require('./configure-sauce-labs.js');
+
+module.exports = function (config) {
+
+    configureSauceLabs(config, 'Safari browsers', {
+        Safari_8: {
+            base: 'SauceLabs',
+            browserName: 'safari',
+            platform: 'OS X 10.10',
+            version: '8.0'
+        },
+        Safari_7: {
+            base: 'SauceLabs',
+            browserName: 'safari',
+            platform: 'OS X 10.9',
+            version: '7.0'
+        },
+        MobileSafari_9: {
+            base: 'SauceLabs',
+            browserName: 'iphone',
+            platform: 'OS X 10.10',
+            version: '9.0'
+        },
+        MobileSafari_8: {
+            base: 'SauceLabs',
+            browserName: 'iphone',
+            platform: 'OS X 10.10',
+            version: '8.4'
+        }
+    });
+
+}


### PR DESCRIPTION
Since the FOSS plan of Sauce Labs only allows 5 concurrent browsers, the
tests are splitted to 3 runs with a different configuration.

Fixes #1259