### PR TITLE
Allow CLIs to read from STDIN

### DIFF
--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -32,7 +32,7 @@ if (typeof require === 'function') {
     try {
         esprima = require('esprima');
     } catch (e) {
-        esprima = require('../src/esprima');
+        esprima = require('../dist/esprima');
     }
 } else if (typeof load === 'function') {
     try {

--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -25,7 +25,7 @@
 
 /*jslint sloppy:true node:true rhino:true */
 
-var fs, esprima, fname, content, options, syntax;
+var fs, esprima, fname, forceFile, content, options, syntax;
 
 if (typeof require === 'function') {
     fs = require('fs');
@@ -53,7 +53,7 @@ if (typeof console === 'undefined' && typeof process === 'undefined') {
 
 function showUsage() {
     console.log('Usage:');
-    console.log('   esparse [options] file.js');
+    console.log('   esparse [options] [file.js]');
     console.log();
     console.log('Available options:');
     console.log();
@@ -68,15 +68,18 @@ function showUsage() {
     process.exit(1);
 }
 
-if (process.argv.length <= 2) {
-    showUsage();
-}
-
 options = {};
 
 process.argv.splice(2).forEach(function (entry) {
 
-    if (entry === '-h' || entry === '--help') {
+    if (forceFile || entry === '-' || entry.slice(0, 1) !== '-') {
+        if (typeof fname === 'string') {
+            console.log('Error: more than one input file.');
+            process.exit(1);
+        } else {
+            fname = entry;
+        }
+    } else if (entry === '-h' || entry === '--help') {
         showUsage();
     } else if (entry === '-v' || entry === '--version') {
         console.log('ECMAScript Parser (using Esprima version', esprima.version, ')');
@@ -94,21 +97,13 @@ process.argv.splice(2).forEach(function (entry) {
         options.tokens = true;
     } else if (entry === '--tolerant') {
         options.tolerant = true;
-    } else if (entry.slice(0, 2) === '--') {
+    } else if (entry === '--') {
+        forceFile = true;
+    } else {
         console.log('Error: unknown option ' + entry + '.');
         process.exit(1);
-    } else if (typeof fname === 'string') {
-        console.log('Error: more than one input file.');
-        process.exit(1);
-    } else {
-        fname = entry;
     }
 });
-
-if (typeof fname !== 'string') {
-    console.log('Error: no input file.');
-    process.exit(1);
-}
 
 // Special handling for regular expression literal since we need to
 // convert it to a string literal, otherwise it will be decoded
@@ -126,7 +121,7 @@ function run(content) {
 }
 
 try {
-    if (fname !== '-') {
+    if (fname && (fname !== '-' || forceFile)) {
         run(fs.readFileSync(fname, 'utf-8'));
     } else {
         var content = '';

--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -29,7 +29,11 @@ var fs, esprima, fname, content, options, syntax;
 
 if (typeof require === 'function') {
     fs = require('fs');
-    esprima = require('esprima');
+    try {
+        esprima = require('esprima');
+    } catch (e) {
+        esprima = require('../src/esprima');
+    }
 } else if (typeof load === 'function') {
     try {
         load('esprima.js');

--- a/bin/esparse.js
+++ b/bin/esparse.js
@@ -120,10 +120,24 @@ function adjustRegexLiteral(key, value) {
     return value;
 }
 
-try {
-    content = fs.readFileSync(fname, 'utf-8');
+function run(content) {
     syntax = esprima.parse(content, options);
     console.log(JSON.stringify(syntax, adjustRegexLiteral, 4));
+}
+
+try {
+    if (fname !== '-') {
+        run(fs.readFileSync(fname, 'utf-8'));
+    } else {
+        var content = '';
+        process.stdin.resume();
+        process.stdin.on('data', function(chunk) {
+            content += chunk;
+        });
+        process.stdin.on('end', function() {
+            run(content);
+        });
+    }
 } catch (e) {
     console.log('Error: ' + e.message);
     process.exit(1);

--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -124,10 +124,13 @@ if (options.format === 'junit') {
 }
 
 count = 0;
-fnames.forEach(function (fname) {
-    var content, timestamp, syntax, name;
+
+function run(fname, content) {
+    var timestamp, syntax, name;
     try {
-        content = fs.readFileSync(fname, 'utf-8');
+        if (typeof content !== 'string') {
+            throw content;
+        }
 
         if (content[0] === '#' && content[1] === '!') {
             content = '//' + content.substr(2, content.length);
@@ -188,6 +191,16 @@ fnames.forEach(function (fname) {
             console.log('Error: ' + e.message);
         }
     }
+}
+
+fnames.forEach(function (fname) {
+    var content;
+    try {
+        content = fs.readFileSync(fname, 'utf-8');
+    } catch (e) {
+        content = e;
+    }
+    run(fname, content);
 });
 
 if (options.format === 'junit') {

--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -36,7 +36,11 @@ if (typeof esprima === 'undefined') {
         esprima = require('./esprima');
     } else if (typeof require === 'function') {
         fs = require('fs');
-        esprima = require('esprima');
+        try {
+            esprima = require('esprima');
+        } catch (e) {
+            esprima = require('../src/esprima');
+        }
     } else if (typeof load === 'function') {
         try {
             load('esprima.js');

--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -39,7 +39,7 @@ if (typeof esprima === 'undefined') {
         try {
             esprima = require('esprima');
         } catch (e) {
-            esprima = require('../src/esprima');
+            esprima = require('../dist/esprima');
         }
     } else if (typeof load === 'function') {
         try {


### PR DESCRIPTION
Makes the input file optional (defaulting to standard input), and allows `-` to explicitly represent standard input.

Example invocations:
```sh
$ echo '"use\x20strict"' | bin/esparse.js -
{
    "type": "Program",
    "body": [
        {
            "type": "ExpressionStatement",
            "expression": {
                "type": "Literal",
                "value": "use strict",
                "raw": "\"use\\x20strict\""
            }
        }
    ],
    "sourceType": "script"
}
$ bin/esvalidate.js <<EOF
"use strict"
)
EOF
Error: Line 2: Unexpected token )
```