### PR TITLE
Fix Program node's sourceType.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -457,7 +457,7 @@ Node.prototype = {
     finishProgram: function(body, sourceType) {
         this.type = Syntax.Program;
         this.body = body;
-        this.sourceType = state.sourceType;
+        this.sourceType = sourceType;
         this.finish();
         return this;
     },


### PR DESCRIPTION
Somehow this was mistakenly introduced during the TypeScript migration.

Refs #1159