### PR TITLE
Downstream tests should be executed using the io.js.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   node:
     version:
-      0.12.0
+      iojs-v1.3.0
   environment:
     NO_WATCH_TESTS: 1
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "codecov" : "istanbul report cobertura && codecov < ./coverage/cobertura-coverage.xml",
     "downstream": "node test/downstream.js",
     "travis": "npm test",
-    "circleci": "npm test && npm run codecov && npm run downstream",
+    "circleci": "npm test && npm run downstream",
     "appveyor": "npm run compile && npm run all-tests && npm run browser-tests && npm run dynamic-analysis",
     "droneio": "npm test && npm run saucelabs-evergreen && npm run saucelabs-ie && npm run saucelabs-safari",
     "generate-regex": "node tools/generate-identifier-regex.js"

--- a/test/downstream.js
+++ b/test/downstream.js
@@ -65,17 +65,13 @@ function test_project(project, repo) {
 }
 
 function test_downstream(projects) {
-    var nodejs_version = 'v0.12',
-        downstream_path;
+    var downstream_path;
 
     if (typeof child_process.execSync !== 'function') {
         console.error('This only works with Node.js that support execSync');
         process.exit(0);
     }
-    if (process.version.indexOf(nodejs_version) !== 0) {
-        console.error('This is intended to run only with Node.js', nodejs_version);
-        process.exit(0);
-    }
+    console.error('Using Node.js', process.version);
 
     downstream_path = temp.mkdirSync('downstream');
     console.log('Running the tests in', downstream_path);


### PR DESCRIPTION
Since Node.js 4 doesn't work (see #1379), let's try something a bit older.