### PR TITLE
AppVeyor CI: Use the most recent Node.js stable (v4).

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: "{build}"
 
 environment:
-  nodejs_version: "0.12"
+  nodejs_version: "4"
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "downstream": "node test/downstream.js",
     "travis": "npm test",
     "circleci": "npm test && npm run codecov && npm run downstream",
-    "appveyor": "npm run compile && npm run all-tests && npm run browser-tests && npm run dynamic-analysis",
+    "appveyor": "npm run compile && npm run all-tests && npm run browser-tests",
     "droneio": "npm test && npm run saucelabs-evergreen && npm run saucelabs-ie && npm run saucelabs-safari",
     "generate-regex": "node tools/generate-identifier-regex.js"
   }


### PR DESCRIPTION
Exclude coverage analysis (already taken care by other CI runs).

Refs #1322