### PR TITLE
Downstream test: remove Istanbul test workaround.

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -54,13 +54,6 @@ function test_project(project, repo) {
     console.log('Replacing esprima.js with a fresh one...');
     copy_file(source, './node_modules/esprima/esprima.js');
 
-    // Temporary workaround: https://github.com/jquery/esprima/issues/1392
-    if (project === 'istanbul') {
-        console.log();
-        console.log(project, 'Disabling browser instrumentation test...');
-        fs.unlinkSync('test/browser/test-browser-instrumentation.js');
-    }
-
     console.log();
     try {
         execute('npm test');


### PR DESCRIPTION
No need to tweak the tests anymore since the problem is solved upstream.

Fixes #1392