### PR TITLE
Move the exported entry points to the main source file

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -54,7 +54,7 @@ interface DeclarationOptions {
     inFor: boolean;
 }
 
-class Parser {
+export class Parser {
     config: Config;
     errorHandler: ErrorHandler;
     scanner: Scanner;
@@ -3402,21 +3402,4 @@ class Parser {
         return exportDeclaration;
     }
 
-}
-
-export function parse(code, options) {
-    const parser = new Parser(code, options);
-    const ast = <any>(parser.parseProgram());
-
-    if (parser.config.comment) {
-        ast.comments = parser.comments;
-    }
-    if (parser.config.tokens) {
-        ast.tokens = parser.tokens;
-    }
-    if (parser.config.tolerant) {
-        ast.errors = parser.errorHandler.errors;
-    }
-
-    return ast;
 }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -75,8 +75,7 @@ class Reader {
 
 }
 
-
-class Tokenizer {
+export class Tokenizer {
     errorHandler: ErrorHandler;
     scanner: Scanner;
     trackRange: boolean;
@@ -173,29 +172,4 @@ class Tokenizer {
         return this.buffer.shift();
     };
 
-}
-
-export function tokenize(code: string, options, delegate) {
-    let tokenizer: Tokenizer = new Tokenizer(code, options);
-
-    let tokens;
-    tokens = [];
-
-    try {
-        while (true) {
-            let token = tokenizer.getNextToken();
-            if (!token) {
-                break;
-            }
-            if (delegate) {
-                token = delegate(token);
-            }
-            tokens.push(token);
-        }
-    } catch (e) {
-        tokenizer.errorHandler.tolerate(e);
-    }
-
-    tokens.errors = tokenizer.errors();
-    return tokens;
 }


### PR DESCRIPTION
This keeps `parser.ts` and `tokenizer.ts` only contain the respective
class and nothing else.

Fixes #1427