### PR TITLE
Travis CI: No need to update npm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-install: "npm update -g npm; npm install"
+install: "npm install"
 script: "npm run travis"
 node_js:
   - iojs


### PR DESCRIPTION
Speculative fix to see if this solves the false alarm when running the tests with Node.js 5 on Travis CI.