### PR TITLE
Travis CI: Remove superfluous npm install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
-install: "npm install"
 script: "npm run travis"
 node_js:
   - iojs


### PR DESCRIPTION
`npm install` is the default if `language` is set to `node_js`.