### PR TITLE
Fix shorthand object destructuring defaults in variable declarations

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1804,6 +1804,7 @@ export class Parser {
             const id = this.parseVariableIdentifier();
             if (this.match('=')) {
                 params.push(keyToken);
+                shorthand = true;
                 this.nextToken();
                 key = id;
                 const expr = this.parseAssignmentExpression();

--- a/test/fixtures/ES6/binding-pattern/array-pattern/patterned-catch.tree.json
+++ b/test/fixtures/ES6/binding-pattern/array-pattern/patterned-catch.tree.json
@@ -454,7 +454,7 @@
                                     },
                                     "kind": "init",
                                     "method": false,
-                                    "shorthand": false
+                                    "shorthand": true
                                 }
                             ]
                         }

--- a/test/fixtures/ES6/binding-pattern/object-pattern/properties.tree.json
+++ b/test/fixtures/ES6/binding-pattern/object-pattern/properties.tree.json
@@ -199,7 +199,7 @@
                                 },
                                 "kind": "init",
                                 "method": false,
-                                "shorthand": false
+                                "shorthand": true
                             },
                             {
                                 "range": [


### PR DESCRIPTION
In a variable declaration, in an object destructuring pattern, a shorthand property with a default value was being incorrectly parsed as having a false shorthand field. For example, the shorthand property in `var {a = b} = c;` was being incorrectly parsed as having a false shorthand field.