### PR TITLE
Fix out-of-bound error location in an invalid string literal

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -882,6 +882,7 @@ export class Scanner {
         }
 
         if (quote !== '') {
+            this.index = start;
             this.throwUnexpectedToken();
         }
 

--- a/test/fixtures/invalid-syntax/migrated_0031.failure.json
+++ b/test/fixtures/invalid-syntax/migrated_0031.failure.json
@@ -1,6 +1,6 @@
 {
-    "index": 7,
+    "index": 0,
     "lineNumber": 1,
-    "column": 8,
+    "column": 1,
     "message": "Error: Line 1: Unexpected token ILLEGAL"
 }

--- a/test/fixtures/invalid-syntax/migrated_0063.failure.json
+++ b/test/fixtures/invalid-syntax/migrated_0063.failure.json
@@ -1,6 +1,6 @@
 {
-    "index": 10,
+    "index": 8,
     "lineNumber": 1,
-    "column": 11,
+    "column": 9,
     "message": "Error: Line 1: Unexpected token ILLEGAL"
 }

--- a/test/fixtures/invalid-syntax/migrated_0168.failure.json
+++ b/test/fixtures/invalid-syntax/migrated_0168.failure.json
@@ -1,6 +1,6 @@
 {
-    "index": 3,
+    "index": 0,
     "lineNumber": 1,
-    "column": 4,
+    "column": 1,
     "message": "Error: Line 1: Unexpected token ILLEGAL"
 }


### PR DESCRIPTION
When a string literal is not valid, mark the initial quote as the error
location since it is considered the offending (illegal) token.

Fixes #1457