### PR TITLE
jspm support: no dependencies in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,8 @@
     "droneio": "npm test && npm run saucelabs-evergreen && npm run saucelabs-ie && npm run saucelabs-safari",
     "generate-regex": "node tools/generate-identifier-regex.js",
     "generate-xhtml-entities": "node tools/generate-xhtml-entities.js"
+  },
+  "jspm": {
+    "dependencies": {}
   }
 }


### PR DESCRIPTION
this allows jspm to install esprima without installing
the nodejs schims for the `fs` and `process` modules.

Reference: https://github.com/jquery/esprima/issues/1486