### PR TITLE
deep clone node when node.shorthand = true

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,6 +42,26 @@ interface MetaNode {
     column: number;
 }
 
+function deepClone(obj) {
+    let res = {}, prop, value;
+    if (!obj) {
+        return obj;
+    }
+
+    for (prop in obj) {
+        if (!obj.hasOwnProperty(prop)) {
+            continue;
+        }
+        value = obj[prop];
+        if (typeof value === 'object') {
+            res[prop] = deepClone(value);
+        } else {
+            res[prop] = value;
+        }
+    }
+    return res;
+}
+
 const ArrowParameterPlaceHolder = 'ArrowParameterPlaceHolder';
 
 interface ArrowParameterPlaceHolderNode {
@@ -871,10 +891,10 @@ export class Parser {
                     this.nextToken();
                     shorthand = true;
                     const init = this.isolateCoverGrammar(this.parseAssignmentExpression);
-                    value = this.finalize(node, new Node.AssignmentPattern(id, init));
+                    value = this.finalize(node, new Node.AssignmentPattern(deepClone(id), init));
                 } else {
                     shorthand = true;
-                    value = id;
+                    value = deepClone(id);
                 }
             } else {
                 this.throwUnexpectedToken(this.nextToken());
@@ -1808,11 +1828,12 @@ export class Parser {
                 this.nextToken();
                 key = id;
                 const expr = this.parseAssignmentExpression();
-                value = this.finalize(this.startNode(keyToken), new Node.AssignmentPattern(id, expr));
+                value = this.finalize(this.startNode(keyToken), new Node.AssignmentPattern(deepClone(id), expr));
             } else if (!this.match(':')) {
                 params.push(keyToken);
                 shorthand = true;
-                key = value = id;
+                key = id;
+                value = deepClone(id);
             } else {
                 this.expect(':');
                 key = id;


### PR DESCRIPTION
case 1:
```
let name = 'test';
let email = ''
let user = {name, email}
```

case 2:

```
let user = {name: 'test', email: 'abc@xxx.com'}
let {name, email} = user;
```

now esprima parse js code into ast as following:
```
{
    "type": "ObjectExpression",
    "properties": [
        {
            "type": "Property",
            "key": {
                "type": "Identifier",
                "name": "name"
            },
            "computed": false,
            "value": {
                "type": "Identifier",
                "name": "name"
            },
            "kind": "init",
            "method": false,
            "shorthand": true
        },
        {
            "type": "Property",
            "key": {
                "type": "Identifier",
                "name": "email"
            },
            "computed": false,
            "value": {
                "type": "Identifier",
                "name": "email"
            },
            "kind": "init",
            "method": false,
            "shorthand": true
        }
    ]
}
```

each property, the  `key` ===  the `value` , so when eshortten change the Identifier name into shortten chars,  bug cames:
```
let {a, b} = user;
```
=====================

this pr deep clone the value object, so the `key` !== `value`, and bug resolved.

ps: the deepClone method should overwrite by typescript, XD
