### PR TITLE
Ignore the catch clause when testing regular expressions

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1072,6 +1072,7 @@ export class Scanner {
         try {
             return new RegExp(pattern, flags);
         } catch (exception) {
+            /* istanbul ignore next */
             return null;
         }
     };


### PR DESCRIPTION
In a JavaScript environment that supports all regular expression flags,
the catch clause has no effect and thus shall be ignored.

Fixes #1512