### PR TITLE
Cross-browser tests: temporarily exclude Internet Explorer 9

### DIFF
--- a/test/saucelabs-ie.conf.js
+++ b/test/saucelabs-ie.conf.js
@@ -14,13 +14,16 @@ module.exports = function (config) {
             browserName: 'internet explorer',
             platform: 'Windows 7',
             version: '10.0'
-        },
+        }
+
+        /*
         IE_9: {
             base: 'SauceLabs',
             browserName: 'internet explorer',
             platform: 'Windows 7',
             version: '9.0'
         }
+        */
     });
 
 }


### PR DESCRIPTION
From the most recent Sauce Labs runs, IE 9 failed to launch.
It is either the problem with IE 9 or Windows 7 or both.