### PR TITLE
Improve class declaration parsing for the default export

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import { assert } from './assert';
-import { Messages} from './messages';
+import { Messages } from './messages';
 
 import { ErrorHandler } from './error-handler';
 import { Token, TokenName } from './token';
@@ -3054,14 +3054,14 @@ export class Parser {
         return this.finalize(node, new Node.ClassBody(elementList));
     }
 
-    parseClassDeclaration(): Node.ClassDeclaration {
+    parseClassDeclaration(identifierIsOptional?: boolean): Node.ClassDeclaration {
         const node = this.createNode();
 
         const previousStrict = this.context.strict;
         this.context.strict = true;
         this.expectKeyword('class');
 
-        let id = this.parseVariableIdentifier();
+        const id = (identifierIsOptional && (this.lookahead.type !== Token.Identifier)) ? null : this.parseVariableIdentifier();
         let superClass = null;
         if (this.matchKeyword('extends')) {
             this.nextToken();
@@ -3254,8 +3254,7 @@ export class Parser {
                 exportDeclaration = this.finalize(node, new Node.ExportDefaultDeclaration(declaration));
             } else if (this.matchKeyword('class')) {
                 // export default class foo {}
-                let declaration = this.parseClassExpression();
-                declaration.type = Syntax.ClassDeclaration;
+                const declaration = this.parseClassDeclaration(true);
                 exportDeclaration = this.finalize(node, new Node.ExportDefaultDeclaration(declaration));
             } else {
                 if (this.matchContextualKeyword('from')) {

--- a/test/fixtures/ES6/export-declaration/export-default-named-class.js
+++ b/test/fixtures/ES6/export-declaration/export-default-named-class.js
@@ -1,0 +1,1 @@
+export default class foo {}

--- a/test/fixtures/ES6/export-declaration/export-default-named-class.tree.json
+++ b/test/fixtures/ES6/export-declaration/export-default-named-class.tree.json
@@ -1,0 +1,201 @@
+{
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                0,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "type": "ExportDefaultDeclaration",
+            "declaration": {
+                "range": [
+                    15,
+                    27
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 27
+                    }
+                },
+                "type": "ClassDeclaration",
+                "id": {
+                    "range": [
+                        21,
+                        24
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 21
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 24
+                        }
+                    },
+                    "type": "Identifier",
+                    "name": "foo"
+                },
+                "superClass": null,
+                "body": {
+                    "range": [
+                        25,
+                        27
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 27
+                        }
+                    },
+                    "type": "ClassBody",
+                    "body": []
+                }
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "default",
+            "range": [
+                7,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                15,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "range": [
+                21,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        27
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 27
+        }
+    }
+}


### PR DESCRIPTION
When parsing `export default class`, treat it as a real class declaration
and do not perform the two-step process (parse as a class expression and then
mutate the node into a class declaration).

Fixes #1570