### PR TITLE
Explicitly distinguish parsing a module vs a script

### DIFF
--- a/src/esprima.ts
+++ b/src/esprima.ts
@@ -27,7 +27,7 @@ import { Parser } from './parser';
 import { JSXParser } from './jsx-parser';
 import { Tokenizer } from './tokenizer';
 
-export function parse(code, options, delegate) {
+export function parse(code: string, options, delegate) {
     let commentHandler: CommentHandler | null = null;
     const proxyDelegate = function(node, metadata) {
         if (delegate) {
@@ -51,6 +51,11 @@ export function parse(code, options, delegate) {
         }
     }
 
+    let isModule = false;
+    if (options && typeof options.sourceType === 'string') {
+        isModule = (options.sourceType === 'module');
+    }
+
     let parser: Parser;
     if (options && typeof options.jsx === 'boolean' && options.jsx) {
         parser = new JSXParser(code, options, parserDelegate);
@@ -58,7 +63,8 @@ export function parse(code, options, delegate) {
         parser = new Parser(code, options, parserDelegate);
     }
 
-    const ast = <any>(parser.parseProgram());
+    const program = isModule ? parser.parseModule() : parser.parseScript();
+    const ast = <any>(program);
 
     if (collectComment && commentHandler) {
         ast.comments = commentHandler.comments;
@@ -71,6 +77,18 @@ export function parse(code, options, delegate) {
     }
 
     return ast;
+}
+
+export function parseModule(code: string, options, delegate) {
+    let parsingOptions = options || {};
+    parsingOptions.sourceType = 'module';
+    return parse(code, parsingOptions, delegate);
+}
+
+export function parseScript(code: string, options, delegate) {
+    let parsingOptions = options || {};
+    parsingOptions.sourceType = 'script';
+    return parse(code, parsingOptions, delegate);
 }
 
 export function tokenize(code: string, options, delegate) {

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -482,6 +482,17 @@ export class MethodDefinition {
     }
 }
 
+export class Module {
+    readonly type: string;
+    readonly body: StatementListItem[];
+    readonly sourceType: string;
+    constructor(body: StatementListItem[]) {
+        this.type = Syntax.Program;
+        this.body = body;
+        this.sourceType = 'module';
+    }
+}
+
 export class NewExpression {
     readonly type: string;
     readonly callee: Expression;
@@ -508,17 +519,6 @@ export class ObjectPattern {
     constructor(properties: Property[]) {
         this.type = Syntax.ObjectPattern;
         this.properties = properties;
-    }
-}
-
-export class Program {
-    readonly type: string;
-    readonly body: StatementListItem[];
-    readonly sourceType: string;
-    constructor(body: StatementListItem[], sourceType: string) {
-        this.type = Syntax.Program;
-        this.body = body;
-        this.sourceType = sourceType;
     }
 }
 
@@ -569,6 +569,17 @@ export class ReturnStatement {
     constructor(argument: Expression | null) {
         this.type = Syntax.ReturnStatement;
         this.argument = argument;
+    }
+}
+
+export class Script {
+    readonly type: string;
+    readonly body: StatementListItem[];
+    readonly sourceType: string;
+    constructor(body: StatementListItem[]) {
+        this.type = Syntax.Program;
+        this.body = body;
+        this.sourceType = 'script';
     }
 }
 

--- a/test/api-tests.js
+++ b/test/api-tests.js
@@ -275,6 +275,365 @@ describe('esprima.parse', function () {
     });
 });
 
+describe('esprima.parseModule', function () {
+
+    it('should not accept zero parameter', function () {
+        assert.throws(function () {
+            esprima.parseModule();
+        });
+    });
+
+    it('should accept one string parameter', function () {
+        assert.doesNotThrow(function () {
+            esprima.parseModule('function f(){}');
+        });
+    });
+
+    it('should accept a String object', function () {
+        assert.doesNotThrow(function () {
+            esprima.parseModule(new String('some.property = value'));
+        });
+    });
+
+    it('should accept two parameters (source and parsing options)', function () {
+        var options = { range: false };
+        assert.doesNotThrow(function () {
+            esprima.parseModule('var x', options);
+        });
+    });
+
+    it('should accept three parameters (source, options, and delegate)', function () {
+        var options = { range: false };
+        assert.doesNotThrow(function () {
+            esprima.parseModule('var x', options, function f(entry) {
+                return entry;
+            });
+        });
+    });
+
+    it('should exclude location information by default', function () {
+        var ast = esprima.parseModule('answer = 42');
+        assert.ifError(ast.range);
+        assert.ifError(ast.loc);
+    });
+
+    it('should exclude comments by default', function () {
+        var ast = esprima.parseModule('42 // answer');
+        assert.ifError(ast.comments);
+    });
+
+    it('should exclude list of tokens by default', function () {
+        var ast = esprima.parseModule('3.14159');
+        assert.ifError(ast.tokens);
+    });
+
+    it('should include index-based location for the nodes when specified', function () {
+        var ast = esprima.parseModule('answer = 42', { range: true });
+        assert.deepEqual(ast.range, [0, 11]);
+        assert.ifError(ast.loc);
+    });
+
+    it('should include line and column-based location for the nodes when specified', function () {
+        var ast = esprima.parseModule('answer = 42', { loc: true });
+        assert.deepEqual(ast.loc.start, { line: 1, column: 0 });
+        assert.deepEqual(ast.loc.end, { line: 1, column: 11 });
+        assert.ifError(ast.loc.source);
+        assert.ifError(ast.range);
+    });
+
+    it('should include source information for the nodes when specified', function () {
+        var ast = esprima.parseModule('answer = 42', { loc: true, source: 'example.js' });
+        assert.deepEqual(ast.loc.source, 'example.js');
+        assert.ifError(ast.range);
+    });
+
+    it('should include the list of comments when specified', function () {
+        var ast = esprima.parseModule('42 // answer', { comment: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0], { type: 'Line', value: ' answer' });
+    });
+
+    it('should include the list of comments with index-based location when specified', function () {
+        var ast = esprima.parseModule('42 // answer', { comment: true, range: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0], { type: 'Line', value: ' answer', range: [3, 12] });
+    });
+
+    it('should include the list of comments with line and column-based location when specified', function () {
+        var ast = esprima.parseModule('42 // answer', { comment: true, loc: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0].type, 'Line');
+        assert.deepEqual(ast.comments[0].value, ' answer');
+        assert.deepEqual(ast.comments[0].loc.start, { line: 1, column: 3 });
+        assert.deepEqual(ast.comments[0].loc.end, { line: 1, column: 12 });
+        assert.ifError(ast.comments[0].range);
+    });
+
+    it('should be able to attach comments', function () {
+        var ast, statement, expression, comments;
+
+        ast = esprima.parseModule('/* universe */ 42', { attachComment: true });
+        statement = ast.body[0];
+        expression = statement.expression;
+        comments = statement.leadingComments;
+
+        assert.deepEqual(expression, { type: 'Literal', value: 42, raw: '42' });
+        assert.deepEqual(statement.leadingComments, [{ type: 'Block', value: ' universe ', range: [0, 14] }]);
+    });
+
+    it('should not implicity collect comments when comment attachment is specified', function () {
+        var ast = esprima.parseModule('/* universe */ 42', { attachComment: true });
+        assert.equal(ast.comments, undefined);
+    });
+
+    it('should include the list of tokens when specified', function () {
+        var ast = esprima.parseModule('x = 1', { tokens: true });
+        assert.deepEqual(ast.tokens.length, 3);
+        assert.deepEqual(ast.tokens[0], { type: 'Identifier', value: 'x' });
+        assert.deepEqual(ast.tokens[1], { type: 'Punctuator', value: '=' });
+        assert.deepEqual(ast.tokens[2], { type: 'Numeric', value: '1' });
+    });
+
+    it('should include the list of tokens with index-based location when specified', function () {
+        var ast = esprima.parseModule('y = 2', { tokens: true, range: true });
+        assert.deepEqual(ast.tokens[0], { type: 'Identifier', value: 'y', range: [0, 1] });
+        assert.deepEqual(ast.tokens[1], { type: 'Punctuator', value: '=', range: [2, 3] });
+        assert.deepEqual(ast.tokens[2], { type: 'Numeric', value: '2', range: [4, 5] });
+    });
+
+    it('should include the list of tokens with line and column-based location when specified', function () {
+        var ast = esprima.parseModule('z = 3', { tokens: true, loc: true });
+        assert.deepEqual(ast.tokens.length, 3);
+        assert.deepEqual(ast.tokens[0].type, 'Identifier');
+        assert.deepEqual(ast.tokens[0].value, 'z');
+        assert.deepEqual(ast.tokens[0].loc.start, { line: 1, column: 0 });
+        assert.deepEqual(ast.tokens[0].loc.end, { line: 1, column: 1 });
+        assert.ifError(ast.tokens[0].range);
+    });
+
+    it('should not understand JSX syntax by default', function () {
+        assert.throws(function () {
+            esprima.parseModule('<head/>');
+        });
+    });
+
+    it('should not understand JSX syntax if it is explicitly not to be supported', function () {
+        assert.throws(function () {
+            esprima.parseModule('<b/>', { jsx: false });
+        });
+    });
+
+    it('should understand JSX syntax if specified', function () {
+        var ast, statement, expression;
+        ast = esprima.parseModule('<title/>', { jsx: true });
+        statement = ast.body[0];
+        expression = statement.expression;
+
+        assert.deepEqual(expression.type, 'JSXElement');
+        assert.deepEqual(expression.openingElement.type, 'JSXOpeningElement');
+        assert.deepEqual(expression.openingElement.name, { type: 'JSXIdentifier', name: 'title' });
+        assert.deepEqual(expression.closingElement, null);
+    });
+
+    it('should never produce shallow copied nodes', function () {
+        var ast, pattern, expr;
+        ast = esprima.parseModule('let {a, b} = {x, y, z}');
+        pattern = ast.body[0].declarations[0].id;
+        expr = ast.body[0].declarations[0].init;
+        pattern.properties[0].key.name = 'foo';
+        expr.properties[0].key.name = 'bar';
+
+        assert.deepEqual(pattern.properties[0].value, { type: 'Identifier', name: 'a' });
+        assert.deepEqual(pattern.properties[1].value, { type: 'Identifier', name: 'b' });
+        assert.deepEqual(expr.properties[0].value, { type: 'Identifier', name: 'x' });
+        assert.deepEqual(expr.properties[1].value, { type: 'Identifier', name: 'y' });
+        assert.deepEqual(expr.properties[2].value, { type: 'Identifier', name: 'z' });
+    });
+
+    it('should perform strict mode parsing', function () {
+        assert.throws(function () {
+            esprima.parseModule('with (x) {}');
+        });
+    });
+
+});
+
+describe('esprima.parseScript', function () {
+
+    it('should not accept zero parameter', function () {
+        assert.throws(function () {
+            esprima.parseScript();
+        });
+    });
+
+    it('should accept one string parameter', function () {
+        assert.doesNotThrow(function () {
+            esprima.parseScript('function f(){}');
+        });
+    });
+
+    it('should accept a String object', function () {
+        assert.doesNotThrow(function () {
+            esprima.parseScript(new String('some.property = value'));
+        });
+    });
+
+    it('should accept two parameters (source and parsing options)', function () {
+        var options = { range: false };
+        assert.doesNotThrow(function () {
+            esprima.parseScript('var x', options);
+        });
+    });
+
+    it('should accept three parameters (source, options, and delegate)', function () {
+        var options = { range: false };
+        assert.doesNotThrow(function () {
+            esprima.parseScript('var x', options, function f(entry) {
+                return entry;
+            });
+        });
+    });
+
+    it('should exclude location information by default', function () {
+        var ast = esprima.parseScript('answer = 42');
+        assert.ifError(ast.range);
+        assert.ifError(ast.loc);
+    });
+
+    it('should exclude comments by default', function () {
+        var ast = esprima.parseScript('42 // answer');
+        assert.ifError(ast.comments);
+    });
+
+    it('should exclude list of tokens by default', function () {
+        var ast = esprima.parseScript('3.14159');
+        assert.ifError(ast.tokens);
+    });
+
+    it('should include index-based location for the nodes when specified', function () {
+        var ast = esprima.parseScript('answer = 42', { range: true });
+        assert.deepEqual(ast.range, [0, 11]);
+        assert.ifError(ast.loc);
+    });
+
+    it('should include line and column-based location for the nodes when specified', function () {
+        var ast = esprima.parseScript('answer = 42', { loc: true });
+        assert.deepEqual(ast.loc.start, { line: 1, column: 0 });
+        assert.deepEqual(ast.loc.end, { line: 1, column: 11 });
+        assert.ifError(ast.loc.source);
+        assert.ifError(ast.range);
+    });
+
+    it('should include source information for the nodes when specified', function () {
+        var ast = esprima.parseScript('answer = 42', { loc: true, source: 'example.js' });
+        assert.deepEqual(ast.loc.source, 'example.js');
+        assert.ifError(ast.range);
+    });
+
+    it('should include the list of comments when specified', function () {
+        var ast = esprima.parseScript('42 // answer', { comment: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0], { type: 'Line', value: ' answer' });
+    });
+
+    it('should include the list of comments with index-based location when specified', function () {
+        var ast = esprima.parseScript('42 // answer', { comment: true, range: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0], { type: 'Line', value: ' answer', range: [3, 12] });
+    });
+
+    it('should include the list of comments with line and column-based location when specified', function () {
+        var ast = esprima.parseScript('42 // answer', { comment: true, loc: true });
+        assert.deepEqual(ast.comments.length, 1);
+        assert.deepEqual(ast.comments[0].type, 'Line');
+        assert.deepEqual(ast.comments[0].value, ' answer');
+        assert.deepEqual(ast.comments[0].loc.start, { line: 1, column: 3 });
+        assert.deepEqual(ast.comments[0].loc.end, { line: 1, column: 12 });
+        assert.ifError(ast.comments[0].range);
+    });
+
+    it('should be able to attach comments', function () {
+        var ast, statement, expression, comments;
+
+        ast = esprima.parseScript('/* universe */ 42', { attachComment: true });
+        statement = ast.body[0];
+        expression = statement.expression;
+        comments = statement.leadingComments;
+
+        assert.deepEqual(expression, { type: 'Literal', value: 42, raw: '42' });
+        assert.deepEqual(statement.leadingComments, [{ type: 'Block', value: ' universe ', range: [0, 14] }]);
+    });
+
+    it('should not implicity collect comments when comment attachment is specified', function () {
+        var ast = esprima.parseScript('/* universe */ 42', { attachComment: true });
+        assert.equal(ast.comments, undefined);
+    });
+
+    it('should include the list of tokens when specified', function () {
+        var ast = esprima.parseScript('x = 1', { tokens: true });
+        assert.deepEqual(ast.tokens.length, 3);
+        assert.deepEqual(ast.tokens[0], { type: 'Identifier', value: 'x' });
+        assert.deepEqual(ast.tokens[1], { type: 'Punctuator', value: '=' });
+        assert.deepEqual(ast.tokens[2], { type: 'Numeric', value: '1' });
+    });
+
+    it('should include the list of tokens with index-based location when specified', function () {
+        var ast = esprima.parseScript('y = 2', { tokens: true, range: true });
+        assert.deepEqual(ast.tokens[0], { type: 'Identifier', value: 'y', range: [0, 1] });
+        assert.deepEqual(ast.tokens[1], { type: 'Punctuator', value: '=', range: [2, 3] });
+        assert.deepEqual(ast.tokens[2], { type: 'Numeric', value: '2', range: [4, 5] });
+    });
+
+    it('should include the list of tokens with line and column-based location when specified', function () {
+        var ast = esprima.parseScript('z = 3', { tokens: true, loc: true });
+        assert.deepEqual(ast.tokens.length, 3);
+        assert.deepEqual(ast.tokens[0].type, 'Identifier');
+        assert.deepEqual(ast.tokens[0].value, 'z');
+        assert.deepEqual(ast.tokens[0].loc.start, { line: 1, column: 0 });
+        assert.deepEqual(ast.tokens[0].loc.end, { line: 1, column: 1 });
+        assert.ifError(ast.tokens[0].range);
+    });
+
+    it('should not understand JSX syntax by default', function () {
+        assert.throws(function () {
+            esprima.parseScript('<head/>');
+        });
+    });
+
+    it('should not understand JSX syntax if it is explicitly not to be supported', function () {
+        assert.throws(function () {
+            esprima.parseScript('<b/>', { jsx: false });
+        });
+    });
+
+    it('should understand JSX syntax if specified', function () {
+        var ast, statement, expression;
+        ast = esprima.parseScript('<title/>', { jsx: true });
+        statement = ast.body[0];
+        expression = statement.expression;
+
+        assert.deepEqual(expression.type, 'JSXElement');
+        assert.deepEqual(expression.openingElement.type, 'JSXOpeningElement');
+        assert.deepEqual(expression.openingElement.name, { type: 'JSXIdentifier', name: 'title' });
+        assert.deepEqual(expression.closingElement, null);
+    });
+
+    it('should never produce shallow copied nodes', function () {
+        var ast, pattern, expr;
+        ast = esprima.parseScript('let {a, b} = {x, y, z}');
+        pattern = ast.body[0].declarations[0].id;
+        expr = ast.body[0].declarations[0].init;
+        pattern.properties[0].key.name = 'foo';
+        expr.properties[0].key.name = 'bar';
+
+        assert.deepEqual(pattern.properties[0].value, { type: 'Identifier', name: 'a' });
+        assert.deepEqual(pattern.properties[1].value, { type: 'Identifier', name: 'b' });
+        assert.deepEqual(expr.properties[0].value, { type: 'Identifier', name: 'x' });
+        assert.deepEqual(expr.properties[1].value, { type: 'Identifier', name: 'y' });
+        assert.deepEqual(expr.properties[2].value, { type: 'Identifier', name: 'z' });
+    });
+});
+
 describe('esprima.parse delegate', function () {
 
     it('should receive all the nodes', function () {

--- a/test/utils/evaluate-testcase.js
+++ b/test/utils/evaluate-testcase.js
@@ -142,7 +142,8 @@
             tree = esprima.parse(code, { jsx: options.jsx, tolerant: options.tolerant, sourceType: options.sourceType, range: true });
             tree = esprima.parse(code, { jsx: options.jsx, tolerant: options.tolerant, sourceType: options.sourceType, loc: true });
 
-            tree = esprima.parse(code, options);
+            tree = (options.sourceType === 'script') ? esprima.parseScript(code, options) : esprima.parseModule(code, options);
+            esprima.parse(code, options);
 
             if (options.tolerant) {
                 for (i = 0, len = tree.errors.length; i < len; i += 1) {
@@ -221,6 +222,7 @@
         // Exercise more code paths with the delegate
         try {
             esprima.parse(code);
+            (options.sourceType === 'module') ? esprima.parseModule(code) : esprima.parseScript(code);
             esprima.parse(code, { range: false, loc: false, comment: false }, filter);
             esprima.parse(code, { range: true,  loc: false, comment: false }, filter);
             esprima.parse(code, { range: false, loc: true,  comment: false }, filter);


### PR DESCRIPTION
`parse` is still supported but the use of it is discouraged.
The consumer must choose between `parseScript` and `parseModule` to perform
a syntactical analysis on a script or a module, respectively.

Fixes #1576