### PR TITLE
Remove unnecessary `operator` property in assignment pattern

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -970,6 +970,7 @@ export class Parser {
                 break;
             case Syntax.AssignmentExpression:
                 expr.type = Syntax.AssignmentPattern;
+                delete expr.operator;
                 this.reinterpretExpressionAsPattern(expr.left);
                 break;
             default:

--- a/test/fixtures/ES6/arrow-function/migrated_0008.tree.json
+++ b/test/fixtures/ES6/arrow-function/migrated_0008.tree.json
@@ -9,7 +9,6 @@
                 "params": [
                     {
                         "type": "AssignmentPattern",
-                        "operator": "=",
                         "left": {
                             "type": "Identifier",
                             "name": "x",

--- a/test/fixtures/ES6/arrow-function/migrated_0013.tree.json
+++ b/test/fixtures/ES6/arrow-function/migrated_0013.tree.json
@@ -9,7 +9,6 @@
                 "params": [
                     {
                         "type": "AssignmentPattern",
-                        "operator": "=",
                         "left": {
                             "type": "Identifier",
                             "name": "eval",

--- a/test/fixtures/ES6/arrow-function/migrated_0014.tree.json
+++ b/test/fixtures/ES6/arrow-function/migrated_0014.tree.json
@@ -27,7 +27,6 @@
                     },
                     {
                         "type": "AssignmentPattern",
-                        "operator": "=",
                         "left": {
                             "type": "Identifier",
                             "name": "a",

--- a/test/fixtures/ES6/destructuring-assignment/array-pattern/nested-assignment.tree.json
+++ b/test/fixtures/ES6/destructuring-assignment/array-pattern/nested-assignment.tree.json
@@ -85,7 +85,6 @@
                                 }
                             },
                             "type": "AssignmentPattern",
-                            "operator": "=",
                             "left": {
                                 "range": [
                                     3,
@@ -140,7 +139,6 @@
                                 }
                             },
                             "type": "AssignmentPattern",
-                            "operator": "=",
                             "left": {
                                 "range": [
                                     7,

--- a/test/fixtures/ES6/destructuring-assignment/object-pattern/object-pattern-assignment.tree.json
+++ b/test/fixtures/ES6/destructuring-assignment/object-pattern/object-pattern-assignment.tree.json
@@ -216,7 +216,6 @@
                                     }
                                 },
                                 "type": "AssignmentPattern",
-                                "operator": "=",
                                 "left": {
                                     "range": [
                                         25,

--- a/test/fixtures/ES6/yield/yield-arrow-parameter-default.tree.json
+++ b/test/fixtures/ES6/yield/yield-arrow-parameter-default.tree.json
@@ -9,7 +9,6 @@
                 "params": [
                     {
                         "type": "AssignmentPattern",
-                        "operator": "=",
                         "left": {
                             "type": "Identifier",
                             "name": "x",

--- a/test/fixtures/ES6/yield/yield-generator-arrow-default.tree.json
+++ b/test/fixtures/ES6/yield/yield-generator-arrow-default.tree.json
@@ -33,7 +33,6 @@
                             "params": [
                                 {
                                     "type": "AssignmentPattern",
-                                    "operator": "=",
                                     "left": {
                                         "type": "Identifier",
                                         "name": "x",


### PR DESCRIPTION
This is for ESTree compatibility.

Fixes #1575