### PR TITLE
add a compile-es2015 npm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test/dist
 src/*.js
 dist/esprima.js
+dist/es2015

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
     "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
     "compile": "tsc -p src/ && webpack && node tools/fixupbundle.js",
+    "compile-es2015": "tsc -p src/ --outdir dist/es2015 --target es2015 -m es2015",
     "test": "npm run compile && npm run all-tests && npm run static-analysis && npm run dynamic-analysis",
     "prepublish": "npm run compile",
     "profile": "node --prof test/profile.js && mv isolate*.log v8.log && node-tick-processor",


### PR DESCRIPTION
https://github.com/toshok/echojs uses esprima and at the moment uses an ancient branch where the IIFE has been manually replaced by an es2015 module.

In the interest of tracking closer to master, this change adds a `compile-es2015` script which generates `dist/es2015/` containing all the files as es2015 modules.
