### PR TITLE
Do not duplicate JSX tokens

### DIFF
--- a/src/jsx-parser.ts
+++ b/src/jsx-parser.ts
@@ -75,6 +75,16 @@ export class JSXParser extends Parser {
         this.nextToken();
     }
 
+    reenterJSX() {
+        this.startJSX();
+        this.expectJSX('}');
+
+        // Pop the closing '}' added from the lookahead.
+        if (this.config.tokens) {
+            this.tokens.pop();
+        }
+    }
+
     createJSXNode(): MetaJSXNode {
         this.collectComments();
         return {
@@ -362,15 +372,14 @@ export class JSXParser extends Parser {
         const node = this.createJSXNode();
 
         this.expectJSX('{');
-        let expression: Node.Expression | null;
-        expression = null;
         this.finishJSX();
+
         if (this.match('}')) {
             this.tolerateError('JSX attributes must only be assigned a non-empty expression');
         }
-        expression = this.parseAssignmentExpression();
-        this.startJSX();
-        this.expectJSX('}');
+
+        const expression = this.parseAssignmentExpression();
+        this.reenterJSX();
 
         return this.finalize(node, new JSXNode.JSXExpressionContainer(expression));
     }
@@ -398,9 +407,8 @@ export class JSXParser extends Parser {
 
         this.finishJSX();
         const argument = this.parseAssignmentExpression();
-        this.startJSX();
+        this.reenterJSX();
 
-        this.expectJSX('}');
         return this.finalize(node, new JSXNode.JSXSpreadAttribute(argument));
     }
 
@@ -462,25 +470,20 @@ export class JSXParser extends Parser {
         return this.finalize(node, new JSXNode.JSXEmptyExpression());
     }
 
-    parseJSXExpression(): Node.Expression | JSXNode.JSXEmptyExpression {
-        let expression;
-
-        if (this.matchJSX('}')) {
-            expression = this.parseJSXEmptyExpression();
-        } else {
-            this.finishJSX();
-            expression = this.parseAssignmentExpression();
-            this.startJSX();
-        }
-
-        return expression;
-    }
-
     parseJSXExpressionContainer(): JSXNode.JSXExpressionContainer {
         const node = this.createJSXNode();
         this.expectJSX('{');
-        const expression = this.parseJSXExpression();
-        this.expectJSX('}');
+
+        let expression: Node.Expression | JSXNode.JSXEmptyExpression;
+        if (this.matchJSX('}')) {
+            expression = this.parseJSXEmptyExpression();
+            this.expectJSX('}');
+        } else {
+            this.finishJSX();
+            expression = this.parseAssignmentExpression();
+            this.reenterJSX();
+        }
+
         return this.finalize(node, new JSXNode.JSXExpressionContainer(expression));
     }
 

--- a/test/fixtures/JSX/attribute-expression.tree.json
+++ b/test/fixtures/JSX/attribute-expression.tree.json
@@ -324,24 +324,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                13,
-                14
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 13
-                },
-                "end": {
-                    "line": 1,
-                    "column": 14
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": ">",
             "range": [
                 14,

--- a/test/fixtures/JSX/attribute-primary.tree.json
+++ b/test/fixtures/JSX/attribute-primary.tree.json
@@ -291,24 +291,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                15,
-                16
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 15
-                },
-                "end": {
-                    "line": 1,
-                    "column": 16
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": "/",
             "range": [
                 16,

--- a/test/fixtures/JSX/attribute-spread.tree.json
+++ b/test/fixtures/JSX/attribute-spread.tree.json
@@ -271,24 +271,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                16,
-                17
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 16
-                },
-                "end": {
-                    "line": 1,
-                    "column": 17
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": ">",
             "range": [
                 17,

--- a/test/fixtures/JSX/container-object-expression.tree.json
+++ b/test/fixtures/JSX/container-object-expression.tree.json
@@ -365,24 +365,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                19,
-                20
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 19
-                },
-                "end": {
-                    "line": 1,
-                    "column": 20
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": "<",
             "range": [
                 20,

--- a/test/fixtures/JSX/container-series.tree.json
+++ b/test/fixtures/JSX/container-series.tree.json
@@ -341,24 +341,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                8,
-                9
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 8
-                },
-                "end": {
-                    "line": 1,
-                    "column": 9
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": "{",
             "range": [
                 9,
@@ -413,24 +395,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                11,
-                12
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 11
-                },
-                "end": {
-                    "line": 1,
-                    "column": 12
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": "{",
             "range": [
                 12,
@@ -462,24 +426,6 @@
                 "end": {
                     "line": 1,
                     "column": 14
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
-            "value": "}",
-            "range": [
-                14,
-                15
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 14
-                },
-                "end": {
-                    "line": 1,
-                    "column": 15
                 }
             }
         },

--- a/test/fixtures/JSX/simple-expression-container.tree.json
+++ b/test/fixtures/JSX/simple-expression-container.tree.json
@@ -271,24 +271,6 @@
         },
         {
             "type": "Punctuator",
-            "value": "}",
-            "range": [
-                16,
-                17
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 16
-                },
-                "end": {
-                    "line": 1,
-                    "column": 17
-                }
-            }
-        },
-        {
-            "type": "Punctuator",
             "value": "<",
             "range": [
                 17,


### PR DESCRIPTION
Reentry to the JSX world means that the last lookahead token being collected
needs to be excluded.

Fixes #1613