### PR TITLE
Reuse existed `parseSuper` method.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1238,17 +1238,8 @@ export class Parser {
         const previousAllowIn = this.context.allowIn;
         this.context.allowIn = true;
 
-        let expr;
-        if (this.matchKeyword('super') && this.context.inFunctionBody) {
-            expr = this.createNode();
-            this.nextToken();
-            expr = this.finalize(expr, new Node.Super());
-            if (!this.match('(') && !this.match('.') && !this.match('[')) {
-                this.throwUnexpectedToken(this.lookahead);
-            }
-        } else {
-            expr = this.inheritCoverGrammar(this.matchKeyword('new') ? this.parseNewExpression : this.parsePrimaryExpression);
-        }
+        let expr = (this.matchKeyword('super') && this.context.inFunctionBody) ? this.parseSuper(/* allowCall */ true) :
+            this.inheritCoverGrammar(this.matchKeyword('new') ? this.parseNewExpression : this.parsePrimaryExpression);
 
         while (true) {
             if (this.match('.')) {
@@ -1292,14 +1283,12 @@ export class Parser {
         return expr;
     }
 
-    parseSuper(): Node.Super {
+    parseSuper(allowCall = false): Node.Super {
         const node = this.createNode();
-
-        this.expectKeyword('super');
-        if (!this.match('[') && !this.match('.')) {
+        this.nextToken();
+        if (!this.match('[') && !this.match('.') && !(allowCall && this.match('('))) {
             this.throwUnexpectedToken(this.lookahead);
         }
-
         return this.finalize(node, new Node.Super());
     }
 


### PR DESCRIPTION
Reuse existed `parseSuper` method for parsing LHS-expressions with allow call.