### PR TITLE
esvalidate: Ensure the consistency of error message

### DIFF
--- a/bin/esvalidate.js
+++ b/bin/esvalidate.js
@@ -194,7 +194,7 @@ function run(fname, content) {
             console.log(' </testcase>');
             console.log('</testsuite>');
         } else {
-            console.log('Error: ' + e.message);
+            console.log(fname + ':' + e.lineNumber + ': ' + e.message.replace(/^Line\ [0-9]*\:\ /, ''));
         }
     }
 }


### PR DESCRIPTION
The error message of a fatal (non-tolerated) error should be similar with that
of a tolerated one, i.e. it should include the name of the input file which
triggers the error.

Fix #1688