### PR TITLE
Use the new `as` syntax for type assertions

### DIFF
--- a/src/esprima.ts
+++ b/src/esprima.ts
@@ -64,7 +64,7 @@ export function parse(code: string, options, delegate) {
     }
 
     const program = isModule ? parser.parseModule() : parser.parseScript();
-    const ast = <any>(program);
+    const ast = program as any;
 
     if (collectComment && commentHandler) {
         ast.comments = commentHandler.comments;

--- a/src/jsx-parser.ts
+++ b/src/jsx-parser.ts
@@ -33,16 +33,16 @@ function getQualifiedElementName(elementName: JSXNode.JSXElementName): string {
 
     switch (elementName.type) {
         case JSXSyntax.JSXIdentifier:
-            const id = <JSXNode.JSXIdentifier>(elementName);
+            const id = elementName as JSXNode.JSXIdentifier;
             qualifiedName = id.name;
             break;
         case JSXSyntax.JSXNamespacedName:
-            const ns = <JSXNode.JSXNamespacedName>(elementName);
+            const ns = elementName as JSXNode.JSXNamespacedName;
             qualifiedName = getQualifiedElementName(ns.namespace) + ':' +
                 getQualifiedElementName(ns.name);
             break;
         case JSXSyntax.JSXMemberExpression:
-            const expr = <JSXNode.JSXMemberExpression>(elementName);
+            const expr = elementName as JSXNode.JSXMemberExpression;
             qualifiedName = getQualifiedElementName(expr.object) + '.' +
                 getQualifiedElementName(expr.property);
             break;
@@ -557,7 +557,7 @@ export class JSXParser extends Parser {
             const node = this.createJSXChildNode();
             const element = this.parseJSXBoundaryElement();
             if (element.type === JSXSyntax.JSXOpeningElement) {
-                const opening = <JSXNode.JSXOpeningElement>(element);
+                const opening = element as JSXNode.JSXOpeningElement;
                 if (opening.selfClosing) {
                     const child = this.finalize(node, new JSXNode.JSXElement(opening, [], null));
                     el.children.push(child);
@@ -567,7 +567,7 @@ export class JSXParser extends Parser {
                 }
             }
             if (element.type === JSXSyntax.JSXClosingElement) {
-                el.closing = <JSXNode.JSXClosingElement>(element);
+                el.closing = element as JSXNode.JSXClosingElement;
                 const open = getQualifiedElementName(el.opening.name);
                 const close = getQualifiedElementName(el.closing.name);
                 if (open !== close) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -912,7 +912,7 @@ export class Parser {
             }
         }
 
-        return this.finalize(node, new Node.Property(kind, <Node.PropertyKey>(key), computed, value, method, shorthand));
+        return this.finalize(node, new Node.Property(kind, key as Node.PropertyKey, computed, value, method, shorthand));
     }
 
     parseObjectInitializer(): Node.ObjectExpression {
@@ -1703,7 +1703,7 @@ export class Parser {
                     }
 
                     if (this.context.strict && expr.type === Syntax.Identifier) {
-                        const id = <Node.Identifier>(expr);
+                        const id = expr as Node.Identifier;
                         if (this.scanner.isRestrictedWord(id.name)) {
                             this.tolerateUnexpectedToken(token, Messages.StrictLHSAssignment);
                         }
@@ -1820,7 +1820,7 @@ export class Parser {
         const id = this.parsePattern(params, kind);
 
         if (this.context.strict && id.type === Syntax.Identifier) {
-            if (this.scanner.isRestrictedWord((<Node.Identifier>(id)).name)) {
+            if (this.scanner.isRestrictedWord((id as Node.Identifier).name)) {
                 this.tolerateError(Messages.StrictVarName);
             }
         }
@@ -1859,7 +1859,7 @@ export class Parser {
         const previousLineNumber = this.scanner.lineNumber;
         const previousLineStart = this.scanner.lineStart;
         this.collectComments();
-        const next = <any>this.scanner.lex();
+        const next = this.scanner.lex() as any;
         this.scanner.index = previousIndex;
         this.scanner.lineNumber = previousLineNumber;
         this.scanner.lineStart = previousLineStart;
@@ -2042,7 +2042,7 @@ export class Parser {
         const id = this.parsePattern(params, 'var');
 
         if (this.context.strict && id.type === Syntax.Identifier) {
-            if (this.scanner.isRestrictedWord((<Node.Identifier>(id)).name)) {
+            if (this.scanner.isRestrictedWord((id as Node.Identifier).name)) {
                 this.tolerateError(Messages.StrictVarName);
             }
         }
@@ -2497,7 +2497,7 @@ export class Parser {
         if ((expr.type === Syntax.Identifier) && this.match(':')) {
             this.nextToken();
 
-            const id = <Node.Identifier>(expr);
+            const id = expr as Node.Identifier;
             const key = '$' + id.name;
             if (Object.prototype.hasOwnProperty.call(this.context.labelSet, key)) {
                 this.throwError(Messages.Redeclaration, 'Label', id.name);
@@ -2571,7 +2571,7 @@ export class Parser {
         }
 
         if (this.context.strict && param.type === Syntax.Identifier) {
-            if (this.scanner.isRestrictedWord((<Node.Identifier>(param)).name)) {
+            if (this.scanner.isRestrictedWord((param as Node.Identifier).name)) {
                 this.tolerateError(Messages.StrictCatchVariable);
             }
         }
@@ -2832,7 +2832,7 @@ export class Parser {
             const previousLineNumber = this.scanner.lineNumber;
             const previousLineStart = this.scanner.lineStart;
             this.collectComments();
-            const next = <any>this.scanner.lex();
+            const next = this.scanner.lex() as any;
             this.scanner.index = previousIndex;
             this.scanner.lineNumber = previousLineNumber;
             this.scanner.lineStart = previousLineStart;
@@ -3007,7 +3007,7 @@ export class Parser {
 
             const statement = this.parseDirective();
             body.push(statement);
-            const directive = (<Node.Directive>statement).directive;
+            const directive = (statement as Node.Directive).directive;
             if (typeof directive !== 'string') {
                 break;
             }
@@ -3168,7 +3168,7 @@ export class Parser {
         } else {
             computed = this.match('[');
             key = this.parseObjectPropertyKey();
-            const id = <Node.Identifier>key;
+            const id = key as Node.Identifier;
             if (id.name === 'static' && (this.qualifiedPropertyName(this.lookahead) || this.match('*'))) {
                 token = this.lookahead;
                 isStatic = true;


### PR DESCRIPTION
Fix #1703