### PR TITLE
Downstream test: temporarily exclude escope

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -109,7 +109,7 @@ if (typeof child_process.execSync !== 'function') {
 
 test_downstream({
     'envify': 'https://github.com/hughsk/envify.git',
-    'escope': 'https://github.com/estools/escope.git',
+    // 'escope': 'https://github.com/estools/escope.git',
     'esmangle': 'https://github.com/estools/esmangle.git',
     'escomplex-js': 'https://github.com/philbooth/escomplex-js.git',
     // 'js2coffee': 'https://github.com/js2coffee/js2coffee.git',


### PR DESCRIPTION
Its tests are falling apart for no particular reason.