### PR TITLE
Move if conditions into switch cases

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -635,7 +635,7 @@ export class Scanner {
                         if ('<>=!+-*%&|^/'.indexOf(str) >= 0) {
                             ++this.index;
                         }
-                }
+            }
         }
 
         if (this.index === start) {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -603,36 +603,38 @@ export class Scanner {
                 break;
 
             default:
-                // 4-character punctuator.
                 str = this.source.substr(this.index, 4);
-                if (str === '>>>=') {
-                    this.index += 4;
-                } else {
+                switch (str) {
+                    // 4-character punctuator.
+                    case '>>>=':
+                        this.index += 4;
+                        break;
 
                     // 3-character punctuators.
-                    str = str.substr(0, 3);
-                    if (str === '===' || str === '!==' || str === '>>>' ||
-                        str === '<<=' || str === '>>=' || str === '**=') {
+                    default:
+                        str = str.substr(0, 3);
+                    case '===': case '!==': case '>>>':
+                    case '<<=': case '>>=': case '**=':
                         this.index += 3;
-                    } else {
+                        break;
 
-                        // 2-character punctuators.
+                    // 2-character punctuators.
+                    default:
                         str = str.substr(0, 2);
-                        if (str === '&&' || str === '||' || str === '==' || str === '!=' ||
-                            str === '+=' || str === '-=' || str === '*=' || str === '/=' ||
-                            str === '++' || str === '--' || str === '<<' || str === '>>' ||
-                            str === '&=' || str === '|=' || str === '^=' || str === '%=' ||
-                            str === '<=' || str === '>=' || str === '=>' || str === '**') {
-                            this.index += 2;
-                        } else {
+                    case '&&': case '||': case '==': case '!=':
+                    case '+=': case '-=': case '*=': case '/=':
+                    case '++': case '--': case '<<': case '>>':
+                    case '&=': case '|=': case '^=': case '%=':
+                    case '<=': case '>=': case '=>': case '**':
+                        this.index += 2;
+                        break;
 
-                            // 1-character punctuators.
-                            str = this.source[this.index];
-                            if ('<>=!+-*%&|^/'.indexOf(str) >= 0) {
-                                ++this.index;
-                            }
+                    default:
+                        // 1-character punctuators.
+                        str = str[0];
+                        if ('<>=!+-*%&|^/'.indexOf(str) >= 0) {
+                            ++this.index;
                         }
-                    }
                 }
         }
 


### PR DESCRIPTION
The reason to put a `switch` here was to reduce the binary expressions (i.e., `str === 'operator'`).

And I've changed the line 630, below:

```
                            str = this.source[this.index];
```

to:

```
                        str = str[0];
```

as it might reduce looking at the `this.source` String elements.