### PR TITLE
Downstream test: temporarily exclude redeyed

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -113,7 +113,7 @@ test_downstream({
     'esmangle': 'https://github.com/estools/esmangle.git',
     'escomplex-js': 'https://github.com/philbooth/escomplex-js.git',
     // 'js2coffee': 'https://github.com/js2coffee/js2coffee.git',
-    'redeyed': 'https://github.com/thlorenz/redeyed.git',
+    // 'redeyed': 'https://github.com/thlorenz/redeyed.git',
     'jsfmt': 'https://github.com/rdio/jsfmt.git',
     'assetgraph': 'https://github.com/assetgraph/assetgraph.git',
     'recast': 'https://github.com/benjamn/recast.git',


### PR DESCRIPTION
(while its smoke tests are being investigated)