### PR TITLE
Improve error message upon an invalid JSX element

### DIFF
--- a/src/jsx-parser.ts
+++ b/src/jsx-parser.ts
@@ -15,8 +15,7 @@ interface MetaJSXElement {
 
 const enum JSXToken {
     Identifier = 100,
-    Text,
-    Unknown
+    Text
 }
 
 interface RawJSXToken {
@@ -30,7 +29,6 @@ interface RawJSXToken {
 
 TokenName[JSXToken.Identifier] = 'JSXIdentifier';
 TokenName[JSXToken.Text] = 'JSXText';
-TokenName[JSXToken.Unknown] = 'JSXUnknown';
 
 // Fully qualified element name, e.g. <svg:path> returns "svg:path"
 function getQualifiedElementName(elementName: JSXNode.JSXElementName): string {
@@ -261,17 +259,7 @@ export class JSXParser extends Parser {
             };
         }
 
-        return {
-            type: JSXToken.Unknown,
-            value: '',
-            lineNumber: this.scanner.lineNumber,
-            lineStart: this.scanner.lineStart,
-            start: this.scanner.index,
-            end: this.scanner.index
-        };
-
-        // return this.scanner.lex() as RawJSXToken;
-        // return this.scanner.throwUnexpectedToken();
+        return this.scanner.lex() as RawJSXToken;
     }
 
     nextJSXToken(): RawJSXToken {
@@ -284,10 +272,6 @@ export class JSXParser extends Parser {
         this.lastMarker.index = this.scanner.index;
         this.lastMarker.line = this.scanner.lineNumber;
         this.lastMarker.column = this.scanner.index - this.scanner.lineStart;
-
-        if (token.type === JSXToken.Unknown) {
-            this.scanner.throwUnexpectedToken();
-        }
 
         if (this.config.tokens) {
             this.tokens.push(this.convertToken(token as any));

--- a/test/fixtures/JSX/invalid-closing-trail.failure.json
+++ b/test/fixtures/JSX/invalid-closing-trail.failure.json
@@ -1,1 +1,1 @@
-{"index":3,"lineNumber":1,"column":4,"message":"Error: Line 1: Unexpected token ILLEGAL","description":"Unexpected token ILLEGAL"}
+{"index":3,"lineNumber":1,"column":4,"message":"Error: Line 1: Unexpected token !","description":"Unexpected token !"}

--- a/test/fixtures/JSX/invalid-no-closing.failure.json
+++ b/test/fixtures/JSX/invalid-no-closing.failure.json
@@ -1,1 +1,1 @@
-{"index":4,"lineNumber":2,"column":1,"message":"Error: Line 2: Unexpected token ILLEGAL","description":"Unexpected token ILLEGAL"}
+{"index":4,"lineNumber":2,"column":1,"message":"Error: Line 2: Unexpected end of input","description":"Unexpected end of input"}


### PR DESCRIPTION
Instead of trying to handle it by itself, the special lexer for JSX should
simply defer to the vanilla lexer if it can't understand the upcoming token.

Fix #1815