### PR TITLE
Fix ThrowStatement parsing for multiline TemplateLiterals

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2584,6 +2584,7 @@ export class Parser {
         const node = this.createNode();
         this.expectKeyword('throw');
         const hasLineTerminator = this.hasLineTerminator;
+        const source = this.scanner.source;
 
         let argument;
         try {
@@ -2595,10 +2596,17 @@ export class Parser {
         }
 
         if (hasLineTerminator) {
-            const shouldThrow = !argument ||
-                (argument && argument.type !== 'TemplateLiteral');
+            const isTemplateLiteral =
+                argument && argument.type === 'TemplateLiteral';
+            const hasLineTerminatorBeforeTemplate =
+                isTemplateLiteral &&
+                source.trim().indexOf('\n') < source.trim().indexOf('`');
 
-            if (shouldThrow) {
+            if (
+                !argument ||
+                !isTemplateLiteral ||
+                hasLineTerminatorBeforeTemplate
+            ) {
                 this.throwError(Messages.NewlineAfterThrow);
             }
         }

--- a/test/fixtures/ES6/template-literals/multiline-throw.js
+++ b/test/fixtures/ES6/template-literals/multiline-throw.js
@@ -1,0 +1,2 @@
+throw `Error:
+Generic Error`;

--- a/test/fixtures/ES6/template-literals/multiline-throw.tree.json
+++ b/test/fixtures/ES6/template-literals/multiline-throw.tree.json
@@ -9,71 +9,71 @@
                     {
                         "type": "TemplateElement",
                         "value": {
-                            "raw": "Generic Error",
-                            "cooked": "Generic Error"
+                            "raw": "Error:\nGeneric Error",
+                            "cooked": "Error:\nGeneric Error"
                         },
                         "tail": true,
                         "range": [
-                            8,
-                            23
+                            6,
+                            28
                         ],
                         "loc": {
                             "start": {
-                                "line": 3,
+                                "line": 1,
                                 "column": 6
                             },
                             "end": {
-                                "line": 3,
-                                "column": 21
+                                "line": 2,
+                                "column": 14
                             }
                         }
                     }
                 ],
                 "expressions": [],
                 "range": [
-                    8,
-                    23
+                    6,
+                    28
                 ],
                 "loc": {
                     "start": {
-                        "line": 3,
+                        "line": 1,
                         "column": 6
                     },
                     "end": {
-                        "line": 3,
-                        "column": 21
+                        "line": 2,
+                        "column": 14
                     }
                 }
             },
             "range": [
-                2,
-                24
+                0,
+                29
             ],
             "loc": {
                 "start": {
-                    "line": 3,
+                    "line": 1,
                     "column": 0
                 },
                 "end": {
-                    "line": 3,
-                    "column": 22
+                    "line": 2,
+                    "column": 15
                 }
             }
         }
     ],
     "sourceType": "script",
     "range": [
-        2,
-        24
+        0,
+        29
     ],
     "loc": {
         "start": {
-            "line": 3,
+            "line": 1,
             "column": 0
         },
         "end": {
-            "line": 3,
-            "column": 22
+            "line": 2,
+            "column": 15
         }
     },
     "tokens": [
@@ -81,35 +81,35 @@
             "type": "Keyword",
             "value": "throw",
             "range": [
-                2,
-                7
+                0,
+                5
             ],
             "loc": {
                 "start": {
-                    "line": 3,
+                    "line": 1,
                     "column": 0
                 },
                 "end": {
-                    "line": 3,
+                    "line": 1,
                     "column": 5
                 }
             }
         },
         {
             "type": "Template",
-            "value": "`Generic Error`",
+            "value": "`Error:\nGeneric Error`",
             "range": [
-                8,
-                23
+                6,
+                28
             ],
             "loc": {
                 "start": {
-                    "line": 3,
+                    "line": 1,
                     "column": 6
                 },
                 "end": {
-                    "line": 3,
-                    "column": 21
+                    "line": 2,
+                    "column": 14
                 }
             }
         },
@@ -117,17 +117,17 @@
             "type": "Punctuator",
             "value": ";",
             "range": [
-                23,
-                24
+                28,
+                29
             ],
             "loc": {
                 "start": {
-                    "line": 3,
-                    "column": 21
+                    "line": 2,
+                    "column": 14
                 },
                 "end": {
-                    "line": 3,
-                    "column": 22
+                    "line": 2,
+                    "column": 15
                 }
             }
         }

--- a/test/fixtures/invalid-syntax/migrated_0122.failure.json
+++ b/test/fixtures/invalid-syntax/migrated_0122.failure.json
@@ -1,6 +1,6 @@
 {
-    "index": 5,
-    "lineNumber": 1,
-    "column": 6,
-    "message": "Error: Line 1: Illegal newline after throw"
+    "index": 6,
+    "lineNumber": 2,
+    "column": 1,
+    "message": "Error: Line 2: Illegal newline after throw"
 }

--- a/test/fixtures/invalid-syntax/throw_newline_before_arg.failure.json
+++ b/test/fixtures/invalid-syntax/throw_newline_before_arg.failure.json
@@ -1,0 +1,1 @@
+{"index":29,"lineNumber":3,"column":15,"message":"Error: Line 3: Illegal newline after throw","description":"Illegal newline after throw"}

--- a/test/fixtures/invalid-syntax/throw_newline_before_arg.js
+++ b/test/fixtures/invalid-syntax/throw_newline_before_arg.js
@@ -1,0 +1,3 @@
+throw 
+`Error:
+Generic Error`;

--- a/test/fixtures/statement/throw/migrated_0003.js
+++ b/test/fixtures/statement/throw/migrated_0003.js
@@ -1,0 +1,2 @@
+throw `Error:
+Generic Error`;

--- a/test/fixtures/statement/throw/migrated_0003.js
+++ b/test/fixtures/statement/throw/migrated_0003.js
@@ -1,2 +1,3 @@
-throw `Error:
-Generic Error`;
+
+
+throw `Generic Error`;

--- a/test/fixtures/statement/throw/migrated_0003.tree.json
+++ b/test/fixtures/statement/throw/migrated_0003.tree.json
@@ -1,0 +1,106 @@
+{
+    "type": "Program",
+    "body": [{
+        "type": "ThrowStatement",
+        "argument": {
+            "type": "TemplateLiteral",
+            "quasis": [{
+                "type": "TemplateElement",
+                "value": {
+                    "raw": "Error:\nGeneric Error",
+                    "cooked": "Error:\nGeneric Error"
+                },
+                "tail": true,
+                "range": [6, 28],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 14
+                    }
+                }
+            }],
+            "expressions": [],
+            "range": [6, 28],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            }
+        },
+        "range": [0, 29],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 2,
+                "column": 15
+            }
+        }
+    }],
+    "sourceType": "script",
+    "range": [0, 29],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 15
+        }
+    },
+    "tokens": [{
+        "type": "Keyword",
+        "value": "throw",
+        "range": [0, 5],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 1,
+                "column": 5
+            }
+        }
+    }, {
+        "type": "Template",
+        "value": "`Error:\nGeneric Error`",
+        "range": [6, 28],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 6
+            },
+            "end": {
+                "line": 2,
+                "column": 14
+            }
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [28, 29],
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 14
+            },
+            "end": {
+                "line": 2,
+                "column": 15
+            }
+        }
+    }]
+}


### PR DESCRIPTION
Currently esprima fails to parse multiline `TemplateLiterals`

Issue reported: https://github.com/jquery/esprima/issues/1814