### PR TITLE
Fix the "tokens" and "comment" argument names

### DIFF
--- a/docs/syntactic-analysis.md
+++ b/docs/syntactic-analysis.md
@@ -29,8 +29,8 @@ The description of various parsing configuration is summarized in the following 
 <tr><td>range</td> <td>Boolean</td> <td>false</td> <td>Annotate each node with its index-based location</td></tr>
 <tr><td>loc</td> <td>Boolean</td> <td>false</td> <td>Annotate each node with its column and row-based location</td></tr>
 <tr><td>tolerant</td> <td>Boolean</td> <td>false</td> <td>Tolerate a few cases of syntax errors</td></tr>
-<tr><td>token</td> <td>Boolean</td> <td>false</td> <td>Collect every token</td></tr>
-<tr><td>comments</td> <td>Boolean</td> <td>false</td> <td>Collect every line and block comment</td></tr>
+<tr><td>tokens</td> <td>Boolean</td> <td>false</td> <td>Collect every token</td></tr>
+<tr><td>comment</td> <td>Boolean</td> <td>false</td> <td>Collect every line and block comment</td></tr>
 </table>
 
 ![Runkit with Esprima parse](runkit-parse.png)


### PR DESCRIPTION
Were specified as "token" and "comments" in the description of the parse method