### PR TITLE
Downstream test: disable AssetGraph since it needs Node.js > 6.

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -115,7 +115,7 @@ test_downstream({
     // 'js2coffee': 'https://github.com/js2coffee/js2coffee.git',
     'redeyed': 'https://github.com/thlorenz/redeyed.git',
     'jsfmt': 'https://github.com/rdio/jsfmt.git',
-    'assetgraph': 'https://github.com/assetgraph/assetgraph.git',
+    // 'assetgraph': 'https://github.com/assetgraph/assetgraph.git',
     'recast': 'https://github.com/benjamn/recast.git',
     'rocambole': 'https://github.com/millermedeiros/rocambole.git'
     // 'documentjs': 'https://github.com/bitovi/documentjs.git'


### PR DESCRIPTION
See https://github.com/assetgraph/assetgraph/commit/07242b10. We'll figure out how to adapt to this.