### PR TITLE
Recognize Token.StringLiteral as a ReturnStatement argument.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2453,6 +2453,7 @@ export class Parser {
 
         const hasArgument = (!this.match(';') && !this.match('}') &&
             !this.hasLineTerminator && this.lookahead.type !== Token.EOF) ||
+            this.lookahead.type === Token.StringLiteral ||
             this.lookahead.type === Token.Template;
 
         const argument = hasArgument ? this.parseExpression() : null;

--- a/test/fixtures/statement/return/multiline_string.js
+++ b/test/fixtures/statement/return/multiline_string.js
@@ -1,0 +1,4 @@
+function a() {
+  return 'hello \
+  	world';
+}

--- a/test/fixtures/statement/return/multiline_string.tree.json
+++ b/test/fixtures/statement/return/multiline_string.tree.json
@@ -1,0 +1,278 @@
+{
+    "type": "Program",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "id": {
+                "type": "Identifier",
+                "name": "a",
+                "range": [
+                    9,
+                    10
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 10
+                    }
+                }
+            },
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "body": [
+                    {
+                        "type": "ReturnStatement",
+                        "argument": {
+                            "type": "Literal",
+                            "value": "hello   \tworld",
+                            "raw": "'hello \\\n  \tworld'",
+                            "range": [
+                                24,
+                                42
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 9
+                                }
+                            }
+                        },
+                        "range": [
+                            17,
+                            43
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 10
+                            }
+                        }
+                    }
+                ],
+                "range": [
+                    13,
+                    45
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 13
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 1
+                    }
+                }
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "range": [
+                0,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "sourceType": "script",
+    "range": [
+        0,
+        45
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 4,
+            "column": 1
+        }
+    },
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                11,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "return",
+            "range": [
+                17,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'hello \\\n  \tworld'",
+            "range": [
+                24,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                42,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The return statement currently fails to parse the return argument for multiline strings.

Multiline strings are handled correctly for variables: http://esprima.org/demo/parse.html?code=var%20a%20%3D%20'hello%20%5C%0A%09world'%3B

But they are not properly handled as return statement arguments: http://esprima.org/demo/parse.html?code=function%20a()%20%7B%0A%20%20return%20'hello%20%5C%0A%20%20%09world'%3B%0A%7D

The ReturnStatement argument is null, but it should be: "hello   \tworld"

This is especially troublesome when applied to libraries like Angular Material which rely on multi-line strings (https://github.com/angular/material/blob/5320d225ee5ec72153aab9b670cd358c07313d5a/src/components/autocomplete/js/autocompleteDirective.js#L303).

This fix is similar to the one from #1882 for Token.Template.