### PR TITLE
Downstream test: ignore Recast since its master is flaky

### DIFF
--- a/test/downstream.js
+++ b/test/downstream.js
@@ -116,7 +116,7 @@ test_downstream({
     'redeyed': 'https://github.com/thlorenz/redeyed.git',
     'jsfmt': 'https://github.com/rdio/jsfmt.git',
     // 'assetgraph': 'https://github.com/assetgraph/assetgraph.git',
-    'recast': 'https://github.com/benjamn/recast.git',
+    // 'recast': 'https://github.com/benjamn/recast.git',
     'rocambole': 'https://github.com/millermedeiros/rocambole.git'
     // 'documentjs': 'https://github.com/bitovi/documentjs.git'
     // 'istanbul': 'https://github.com/gotwarlost/istanbul.git'


### PR DESCRIPTION
Recast's TypeScript tests often fail spuriously, sometimes in conjuction with GraphQL,
so let's isolate us from it.