### PR TITLE
Fixed miscalculated 'computed' field

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3240,6 +3240,7 @@ export class Parser {
                 if (punctuator !== ':' && punctuator !== '(' && punctuator !== '*') {
                     isAsync = true;
                     token = this.lookahead;
+                    computed = this.match('[');
                     key = this.parseObjectPropertyKey();
                     if (token.type === Token.Identifier && token.value === 'constructor') {
                         this.tolerateUnexpectedToken(token, Messages.ConstructorIsAsync);

--- a/test/fixtures/es2017/async/methods/class-async-method-computed.tree.json
+++ b/test/fixtures/es2017/async/methods/class-async-method-computed.tree.json
@@ -46,7 +46,7 @@
                                 }
                             }
                         },
-                        "computed": false,
+                        "computed": true,
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,


### PR DESCRIPTION
This PR fixes the last bug of #1699  "`computed` must be true, but it is not."
I added the missing line in `src/parser.ts`

I know that this is the correct fix because I also fixed it in my [forked version of Esprima](https://github.com/MikaelMayer/esprima) where I support all concrete syntax elements in nodes, as well as a basic `.unparse()` method on every node.
All tests pass.

