### PR TITLE
Update README fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A simple example on Node.js REPL:
   { type: 'Punctuator', value: '=' },
   { type: 'Numeric', value: '42' } ]
   
-> esprima.parseScript(program);
+> esprima.parse(program);
 { type: 'Program',
   body:
    [ { type: 'VariableDeclaration',


### PR DESCRIPTION
The `esprima.parseScript` call is outdated, it's now called `esprima.parse`. I've updated README.md to reflect this.

Hope it helps! This is my first contribution, so feel free to modify it if it does not meet the contribution guidelines.