### PR TITLE
Publish esprima js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 coverage
+lib
+lib.es2015
 node_modules
 test/dist
 src/*.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "version": "4.0.1",
   "files": [
     "bin",
-    "dist/esprima.js"
+    "dist/esprima.js",
+    "lib",
+    "lib.es2015"
   ],
   "engines": {
     "node": ">=4"
@@ -93,9 +95,10 @@
     "analyze-coverage": "istanbul cover test/unit-tests.js",
     "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
     "dynamic-analysis": "npm run analyze-coverage && npm run check-coverage",
-    "compile": "tsc -p src/ && webpack && node tools/fixupbundle.js",
+    "compile": "tsc -p src/ --outDir lib && webpack && node tools/fixupbundle.js",
+    "compile.es2015": "tsc -p src/ --outDir lib.es2015 -t ES2015 -m ES2015 -d",
     "test": "npm run compile && npm run all-tests && npm run static-analysis && npm run dynamic-analysis",
-    "prepublish": "npm run compile",
+    "prepublish": "npm run compile && npm run compile.es2015",
     "profile": "node --prof test/profile.js && mv isolate*.log v8.log && node-tick-processor",
     "benchmark-parser": "node -expose_gc test/benchmark-parser.js",
     "benchmark-tokenizer": "node --expose_gc test/benchmark-tokenizer.js",

--- a/src/comment-handler.ts
+++ b/src/comment-handler.ts
@@ -1,19 +1,19 @@
 import { SourceLocation } from './scanner';
 import { Syntax } from './syntax';
 
-interface Comment {
+export interface Comment {
     type: string;
     value: string;
     range?: [number, number];
     loc?: SourceLocation;
 }
 
-interface Entry {
+export interface Entry {
     comment: Comment;
     start: number;
 }
 
-interface NodeInfo {
+export interface NodeInfo {
     node: any;
     start: number;
 }

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-classes-per-file */
 
-declare class Error {
+export declare class Error {
     public name: string;
     public message: string;
     public index: number;

--- a/src/jsx-parser.ts
+++ b/src/jsx-parser.ts
@@ -6,19 +6,19 @@ import { Marker, Parser } from './parser';
 import { Token, TokenName } from './token';
 import { XHTMLEntities } from './xhtml-entities';
 
-interface MetaJSXElement {
+export interface MetaJSXElement {
     node: Marker;
     opening: JSXNode.JSXOpeningElement;
     closing: JSXNode.JSXClosingElement | null;
     children: JSXNode.JSXChild[];
 }
 
-const enum JSXToken {
+export const enum JSXToken {
     Identifier = 100,
     Text
 }
 
-interface RawJSXToken {
+export interface RawJSXToken {
     type: Token | JSXToken;
     value: string;
     lineNumber: number;

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -729,7 +729,7 @@ export class TaggedTemplateExpression {
     }
 }
 
-interface TemplateElementValue {
+export interface TemplateElementValue {
     cooked: string;
     raw: string;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,7 +6,7 @@ import { Comment, RawToken, Scanner, SourceLocation } from './scanner';
 import { Syntax } from './syntax';
 import { Token, TokenName } from './token';
 
-interface Config {
+export interface Config {
     range: boolean;
     loc: boolean;
     source: string | null;
@@ -15,7 +15,7 @@ interface Config {
     tolerant: boolean;
 }
 
-interface Context {
+export interface Context {
     isModule: boolean;
     allowIn: boolean;
     allowStrictDirective: boolean;
@@ -37,19 +37,19 @@ export interface Marker {
     column: number;
 }
 
-const ArrowParameterPlaceHolder = 'ArrowParameterPlaceHolder';
+export const ArrowParameterPlaceHolder = 'ArrowParameterPlaceHolder';
 
-interface ArrowParameterPlaceHolderNode {
+export interface ArrowParameterPlaceHolderNode {
     type: string;
     params: Node.Expression[];
     async: boolean;
 }
 
-interface DeclarationOptions {
+export interface DeclarationOptions {
     inFor: boolean;
 }
 
-interface TokenEntry {
+export interface TokenEntry {
     type: string;
     value: string;
     regex?: {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -46,7 +46,7 @@ export interface RawToken {
     end: number;
 }
 
-interface ScannerState {
+export interface ScannerState {
     index: number;
     lineNumber: number;
     lineStart: number;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,10 +1,10 @@
-import { ErrorHandler } from './error-handler';
+import { Error, ErrorHandler } from './error-handler';
 import { Comment, Scanner, SourceLocation } from './scanner';
 import { Token, TokenName } from './token';
 
-type ReaderEntry = string | null;
+export type ReaderEntry = string | null;
 
-interface BufferEntry {
+export interface BufferEntry {
     type: string;
     value: string;
     regex?: {
@@ -15,7 +15,7 @@ interface BufferEntry {
     loc?: SourceLocation;
 }
 
-class Reader {
+export class Reader {
     readonly values: ReaderEntry[];
     curly: number;
     paren: number;
@@ -93,7 +93,7 @@ class Reader {
 
 /* tslint:disable:max-classes-per-file */
 
-interface Config {
+export interface Config {
     tolerant?: boolean;
     comment?: boolean;
     range?: boolean;
@@ -121,7 +121,7 @@ export class Tokenizer {
         this.reader = new Reader();
     }
 
-    errors() {
+    errors(): Error[] {
         return this.errorHandler.errors;
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    entry:  __dirname + "/src/esprima.js",
+    entry:  __dirname + "/lib/esprima.js",
     output: {
         path:  __dirname + "/dist",
         filename: "esprima.js",


### PR DESCRIPTION
By publishing the ES5 in `lib` and ES2015 and `lib.es2015` to npm, the esprima library can be directly referenced leading to more control over what ends up in a output bundle. While the webpack bundle works well, it is essentially a "binary" that can't be "tree-shaken" to remove support for functionality that isn't needed. In my case, JSX support is not needed, so I want to remove JSX from the output. Having individual files allows me to import only those files necessary to parse scripts.