### PR TITLE
#2005 [Documentation] Add missing VariableDeclaration to For{In,Of}Statement types

### DIFF
--- a/docs/syntax-tree-format.md
+++ b/docs/syntax-tree-format.md
@@ -534,7 +534,7 @@ interface ForStatement {
 ```js
 interface ForInStatement {
     type: 'ForInStatement';
-    left: Expression;
+    left: Expression | VariableDeclaration;
     right: Expression;
     body: Statement;
     each: false;
@@ -546,7 +546,7 @@ interface ForInStatement {
 ```js
 interface ForOfStatement {
     type: 'ForOfStatement';
-    left: Expression;
+    left: Expression | VariableDeclaration;
     right: Expression;
     body: Statement;
 }


### PR DESCRIPTION
Issue: #2005

The documentation only specifies Expression as the value for the left property of ForInStatement and ForOfStatement. This adds the VariableDeclaration type to the left property in the documentation.