### PR TITLE
docs: Fix simple typo, occurence -> occurrence

### DIFF
--- a/test/3rdparty/jquery.mobile-1.4.2.js
+++ b/test/3rdparty/jquery.mobile-1.4.2.js
@@ -4834,7 +4834,7 @@ $.widget( "mobile.page", {
 
 			// Check to see if the page already exists in the DOM.
 			// NOTE do _not_ use the :jqmData pseudo selector because parenthesis
-			//      are a valid url char and it breaks on the first occurence
+			//      are a valid url char and it breaks on the first occurrence
 			page = this.element
 				.children( "[data-" + this._getNs() +"url='" + dataUrl + "']" );
 

--- a/test/3rdparty/yui-3.12.0.js
+++ b/test/3rdparty/yui-3.12.0.js
@@ -368,7 +368,7 @@ proto = {
                 //    can't match "foyui" or "i_heart_simpleyui". This can be anywhere in the string.
                 // 2. After #1 must come a forward slash followed by the string matched in #1, so
                 //    "yui-base/yui-base" or "simpleyui/simpleyui" or "yui-pants/yui-pants".
-                // 3. The second occurence of the #1 token can optionally be followed by "-debug" or "-min",
+                // 3. The second occurrence of the #1 token can optionally be followed by "-debug" or "-min",
                 //    so "yui/yui-min", "yui/yui-debug", "yui-base/yui-base-debug". NOT "yui/yui-tshirt".
                 // 4. This is followed by ".js", so "yui/yui.js", "simpleyui/simpleyui-min.js"
                 // 0. Going back to the beginning, now. If all that stuff in 1-4 comes after a "?" in the string,


### PR DESCRIPTION
There is a small typo in test/3rdparty/jquery.mobile-1.4.2.js, test/3rdparty/yui-3.12.0.js.

Should read `occurrence` rather than `occurence`.

