### PR TITLE
Fix multi-line string literal parsing with CRLF

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1517,7 +1517,8 @@ export class Parser {
                     precedences.pop();
                     left = stack.pop();
                     markers.pop();
-                    const node = this.startNode(markers[markers.length - 1]);
+                    const marker = markers[markers.length - 1];
+                    const node = this.startNode(marker, marker.lineStart);
                     stack.push(this.finalize(node, new Node.BinaryExpression(operator, left, right)));
                 }
 

--- a/test/.gitattributes
+++ b/test/.gitattributes
@@ -1,0 +1,1 @@
+fixtures/expression/binary/multiline_string_literal.js eol=crlf

--- a/test/fixtures/expression/binary/multiline_string_literal.js
+++ b/test/fixtures/expression/binary/multiline_string_literal.js
@@ -1,0 +1,3 @@
+var str = 'test \
+d'+'test \
+test'+'f';

--- a/test/fixtures/expression/binary/multiline_string_literal.tree.json
+++ b/test/fixtures/expression/binary/multiline_string_literal.tree.json
@@ -1,0 +1,332 @@
+    {
+    "range": [
+        0,
+        41
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 10
+        }
+    },
+    "type": "Program",
+    "body": [
+        {
+            "range": [
+                0,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "range": [
+                        4,
+                        40
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 9
+                        }
+                    },
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "range": [
+                            4,
+                            7
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 7
+                            }
+                        },
+                        "type": "Identifier",
+                        "name": "str"
+                    },
+                    "init": {
+                        "range": [
+                            10,
+                            40
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 9
+                            }
+                        },
+                        "type": "BinaryExpression",
+                        "operator": "+",
+                        "left": {
+                            "range": [
+                                10,
+                                36
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 5
+                                }
+                            },
+                            "type": "BinaryExpression",
+                            "operator": "+",
+                            "left": {
+                                "range": [
+                                    10,
+                                    21
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 10
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 2
+                                    }
+                                },
+                                "type": "Literal",
+                                "value": "test d",
+                                "raw": "'test \\\r\nd'"
+                            },
+                            "right": {
+                                "range": [
+                                    22,
+                                    36
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 3
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 5
+                                    }
+                                },
+                                "type": "Literal",
+                                "value": "test test",
+                                "raw": "'test \\\r\ntest'"
+                            }
+                        },
+                        "right": {
+                            "range": [
+                                37,
+                                40
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 9
+                                }
+                            },
+                            "type": "Literal",
+                            "value": "f",
+                            "raw": "'f'"
+                        }
+                    }
+                }
+            ],
+            "kind": "var"
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "range": [
+                0,
+                3
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            },
+            "type": "Keyword",
+            "value": "var"
+        },
+        {
+            "range": [
+                4,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "type": "Identifier",
+            "value": "str"
+        },
+        {
+            "range": [
+                8,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            },
+            "type": "Punctuator",
+            "value": "="
+        },
+        {
+            "range": [
+                10,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 2
+                }
+            },
+            "type": "String",
+            "value": "'test \\\r\nd'"
+        },
+        {
+            "range": [
+                21,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 3
+                }
+            },
+            "type": "Punctuator",
+            "value": "+"
+        },
+        {
+            "range": [
+                22,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 3
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            },
+            "type": "String",
+            "value": "'test \\\r\ntest'"
+        },
+        {
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 6
+                }
+            },
+            "type": "Punctuator",
+            "value": "+"
+        },
+        {
+            "range": [
+                37,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 6
+                },
+                "end": {
+                    "line": 3,
+                    "column": 9
+                }
+            },
+            "type": "String",
+            "value": "'f'"
+        },
+        {
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "type": "Punctuator",
+            "value": ";"
+        }
+    ]
+}


### PR DESCRIPTION
fixes #2032

Trying to parse one file using windows line endings by using targeted .gitattributes. Without it it's hard to enter the path for \r\n.