### PR TITLE
infrastructure: update "engines" to node>=10.9

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: npm ci
     - run: npm run code-style

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 14.x
     - run: npm ci
     - run: npm test
     - run: npm run downstream

--- a/.github/workflows/ecma262suite.yml
+++ b/.github/workflows/ecma262suite.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 14.x
     - run: npm ci
     - run: npm test
     - run: npm run test-262

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - run: git config --global core.autocrlf false
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [6.x]
+        node-version: [8.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist/esprima.js"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10.9"
   },
   "author": {
     "name": "Ariya Hidayat",

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -527,7 +527,7 @@ export class Scanner {
 
             // 3 digits are only allowed when string starts
             // with 0, 1, 2, 3
-            if ('0123'.indexOf(ch) >= 0 && !this.eof() && Character.isOctalDigit(this.source.charCodeAt(this.index))) {
+            if ('0123'.includes(ch) && !this.eof() && Character.isOctalDigit(this.source.charCodeAt(this.index))) {
                 code = code * 8 + octalValue(this.source[this.index++]);
             }
         }
@@ -661,7 +661,7 @@ export class Scanner {
 
                             // 1-character punctuators.
                             str = this.source[this.index];
-                            if ('<>=!+-*%&|^/'.indexOf(str) >= 0) {
+                            if ('<>=!+-*%&|^/'.includes(str)) {
                                 ++this.index;
                             }
                         }
@@ -1136,7 +1136,7 @@ export class Scanner {
         const astralSubstitute = '\uFFFF';
         let tmp = pattern;
 
-        if (flags.indexOf('u') >= 0) {
+        if (flags.includes('u')) {
             tmp = tmp
                 // Replace every Unicode escape sequence with the equivalent
                 // BMP character or a constant ASCII code point in the case of

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,9 +1,10 @@
 {
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "ES6",
 		"module": "commonjs",
 		"noImplicitAny": false,
-		"strict": true
+		"strict": true,
+		"lib": ["ES2015"]
 	},
 	"files": [
 		"assert.ts",


### PR DESCRIPTION
This PR fixes #2056 

* package.json `engines` is updated to node>=10.9
* github actions are updated to by default use 14.x instead of 12.x (or 10.x)
* move node 8.x test runs to legacy, and remove 6.x from legacy
* <del>ts compile target is remained as ES5, as `escomplex-js` depends on `esprima` 1 which doesn't support ES6. </del> While `lib` is changed to ES6, as Node 10.9+ already has full ES6 support, see https://node.green/