### PR TITLE
Update README.md to ES2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the help of [many contributors](https://github.com/jquery/esprima/contribut
 
 ### Features
 
-- Full support for ECMAScript 2017 ([ECMA-262 8th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
+- Full support for ECMAScript 2017 ([ECMA-262 9th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
 - Sensible [syntax tree format](https://github.com/estree/estree/blob/master/es5.md) as standardized by [ESTree project](https://github.com/estree/estree)
 - Experimental support for [JSX](https://facebook.github.io/jsx/), a syntax extension for [React](https://facebook.github.io/react/)
 - Optional tracking of syntax node location (index-based and line-column)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the help of [many contributors](https://github.com/jquery/esprima/contribut
 
 ### Features
 
-- Full support for ECMAScript 2017 ([ECMA-262 9th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
+- Full support for ECMAScript 2018 ([ECMA-262 9th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
 - Sensible [syntax tree format](https://github.com/estree/estree/blob/master/es5.md) as standardized by [ESTree project](https://github.com/estree/estree)
 - Experimental support for [JSX](https://facebook.github.io/jsx/), a syntax extension for [React](https://facebook.github.io/react/)
 - Optional tracking of syntax node location (index-based and line-column)


### PR DESCRIPTION
we now support all of [ES2018](https://github.com/estree/estree/blob/master/es2018.md)

# Statements

```js
extend interface ForOfStatement {
  await: boolean;
}
```

`for-await-of` statements, e.g., `for await (const x of xs) {`

# Expressions

```js
extend interface ObjectExpression {
    properties: [ Property | SpreadElement ];
}
```

Spread properties, e.g., `{a: 1, ...obj, b: 2}`.

# Template Literals

```js
extend interface TemplateElement {
    value: {
        cooked: string | null;
        raw: string;
    };
}
```

If the template literal is tagged and the text has an invalid escape, `cooked` will be `null`, e.g., ``tag`\unicode and \u{55}` ``

# Patterns

```js
extend interface ObjectPattern {
    properties: [ AssignmentProperty | RestElement ];
}
```

Rest properties, e.g., `{a, ...rest} = obj`.