### PR TITLE
Fix curser misplacement in editor

### DIFF
--- a/demo/components.js
+++ b/demo/components.js
@@ -304,6 +304,7 @@ Demo = (function () {
                 language: language,
                 folding: false,
                 lineNumbersMinChars: 3,
+                fontSize: 14,
                 minimap: {
                     enabled: false
                 },


### PR DESCRIPTION
Fixed bug reported in https://github.com/jquery/esprima/issues/2028

After my testing, the cursor misplacement problem only occurs in macOS Chrome. So the solution is that something is interfering with Monaco's cursor positioning.

![image](https://user-images.githubusercontent.com/17287124/121639425-1aac5d00-cabf-11eb-8be6-b28652860f37.png)

The global CSS base configuration interferes with the Monaco editor fonts.

So, We should specify FontStyle in Monaco options, not in our CSS.

After testing, it works well.

