### PR TITLE
Fix missing optional attributes from tree JSON files

### DIFF
--- a/test/fixtures/es2020/import.meta/assignment.module.tree.json
+++ b/test/fixtures/es2020/import.meta/assignment.module.tree.json
@@ -80,6 +80,7 @@
                             }
                         }
                     },
+                    "optional": false,
                     "range": [
                         0,
                         15

--- a/test/fixtures/es2020/import.meta/log.module.tree.json
+++ b/test/fixtures/es2020/import.meta/log.module.tree.json
@@ -44,6 +44,7 @@
                             }
                         }
                     },
+                    "optional": false,
                     "range": [
                         0,
                         11
@@ -114,6 +115,7 @@
                         }
                     }
                 ],
+                "optional": false,
                 "range": [
                     0,
                     24

--- a/test/fixtures/es2020/import.meta/url.module.tree.json
+++ b/test/fixtures/es2020/import.meta/url.module.tree.json
@@ -106,6 +106,7 @@
                                             }
                                         }
                                     },
+                                    "optional": false,
                                     "range": [
                                         8,
                                         23
@@ -155,6 +156,7 @@
                                 }
                             }
                         },
+                        "optional": false,
                         "range": [
                             0,
                             37
@@ -188,6 +190,7 @@
                             }
                         }
                     },
+                    "optional": false,
                     "range": [
                         0,
                         41
@@ -224,6 +227,7 @@
                         }
                     }
                 ],
+                "optional": false,
                 "range": [
                     0,
                     56


### PR DESCRIPTION
Latest merge was missing some optional attributes from JSONs which were introduced by a PR before that, fixed missing attributes.