### PR TITLE
Update readme - Esprima is written in TypeScript, not JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 **Esprima** ([esprima.org](http://esprima.org), BSD license) is a high performance,
 standard-compliant [ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm)
-parser written in ECMAScript (also popularly known as
-[JavaScript](https://en.wikipedia.org/wiki/JavaScript)).
+parser written in [TypeScript](https://www.typescriptlang.org/).
 Esprima is created and maintained by [Ariya Hidayat](https://twitter.com/ariyahidayat),
 with the help of [many contributors](https://github.com/jquery/esprima/contributors).
 


### PR DESCRIPTION
I think the readme should not claim Esprima is written in ECMAScript when in fact it is in TypeScript.