### PR TITLE
fix(docs): update the docs broken link to an archive

### DIFF
--- a/docs/syntax-tree-format.md
+++ b/docs/syntax-tree-format.md
@@ -1,6 +1,6 @@
 # Appendix A. Syntax Tree Format
 
-Esprima syntax tree format is derived from the original version of [Mozilla Parser API](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API), which is then formalized and expanded as the [ESTree specification](https://github.com/estree/estree).
+Esprima syntax tree format is derived from the original version of [Mozilla Parser API](https://web.archive.org/web/20210314002546/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API), which is then formalized and expanded as the [ESTree specification](https://github.com/estree/estree).
 
 **Note**: In the following sections, interfaces are described using the syntax of [TypeScript interface](https://www.typescriptlang.org/docs/handbook/interfaces.html).
 


### PR DESCRIPTION
This PR closes: #2119 and changes the broken link to an archive link